### PR TITLE
Option to disable sql query logging in debug mode

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -464,7 +464,7 @@ class DB:
         
         self._ctx = threadeddict()
         # flag to enable/disable printing queries
-        self.printing = config.get('debug_sql', False) ###@@@ was 'debug'. was irritating :)
+        self.printing = config.get('debug_sql', config.get('debug', False))
         self.supports_multiple_insert = False
         
         try:


### PR DESCRIPTION
Trivial change:
No SQL debug prints unless web.config.debug_sql is set (i.e. off by default. Hope it's OK).
