### PR TITLE
fix miss using arg and clean up code

### DIFF
--- a/experimental/migration.py
+++ b/experimental/migration.py
@@ -72,7 +72,7 @@ class _outputter:
 
 def output(string_):
     """Appends `string_` to the response."""
-    string_ = web.utf8(string_)
+    string_ = web.safestr(string_)
     if web.ctx.get('flush'):
         web.ctx._write(string_)
     else:

--- a/web/application.py
+++ b/web/application.py
@@ -281,7 +281,7 @@ class application:
             except web.HTTPError, e:
                 result = [e.data]
 
-            result = web.utf8(iter(result))
+            result = web.safestr(iter(result))
 
             status, headers = web.ctx.status, web.ctx.headers
             start_resp(status, headers)

--- a/web/http.py
+++ b/web/http.py
@@ -97,7 +97,7 @@ def urlencode(query, doseq=0):
         if doseq and isinstance(value, list):
             return [convert(v) for v in value]
         else:
-            return utils.utf8(value)
+            return utils.safestr(value)
         
     query = dict([(k, convert(v, doseq)) for k, v in query.items()])
     return urllib.urlencode(query, doseq=doseq)

--- a/web/utils.py
+++ b/web/utils.py
@@ -348,7 +348,7 @@ def safestr(obj, encoding='utf-8'):
         '2'
     """
     if isinstance(obj, unicode):
-        return obj.encode('utf-8')
+        return obj.encode(encoding)
     elif isinstance(obj, str):
         return obj
     elif hasattr(obj, 'next') and hasattr(obj, '__iter__'): # iterator

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 import sys, cgi, Cookie, pprint, urlparse, urllib
-from utils import storage, storify, threadeddict, dictadd, intget, utf8
+from utils import storage, storify, threadeddict, dictadd, intget, safestr
 
 config = storage()
 config.__doc__ = """
@@ -210,7 +210,7 @@ def header(hdr, value, unique=False):
     If `unique` is True and a header with that name already exists,
     it doesn't add a new one. 
     """
-    hdr, value = utf8(hdr), utf8(value)
+    hdr, value = safestr(hdr), safestr(value)
     # protection against HTTP response splitting attack
     if '\n' in hdr or '\r' in hdr or '\n' in value or '\r' in value:
         raise ValueError, 'invalid characters in header'
@@ -298,7 +298,7 @@ def setcookie(name, value, expires="", domain=None, secure=False, httponly=False
         kargs['secure'] = secure
     # @@ should we limit cookies to a different path?
     cookie = Cookie.SimpleCookie()
-    cookie[name] = urllib.quote(utf8(value))
+    cookie[name] = urllib.quote(safestr(value))
     for key, val in kargs.iteritems(): 
         cookie[name][key] = val
 


### PR DESCRIPTION
1. the safestr() should using the args, not hard code. 
2. in code  the comment: # for backward-compatibility. so I think wo  should't  using utf8() in webpy code any more.
