### PR TITLE
fix issue that web.py template and jquery incompatible.

### DIFF
--- a/web/template.py
+++ b/web/template.py
@@ -867,6 +867,8 @@ class Template(BaseTemplate):
         
         # support fort \$ for backward-compatibility 
         text = text.replace(r'\$', '$$')
+        text = text.replace(r'$.', '$$.')
+        text = text.replace(r'$(', '$$(')
         return text
     normalize_text = staticmethod(normalize_text)
                 


### PR DESCRIPTION
web.py template is not complete compatible with jquery.
for example , "$.ajax('aaa.com')" will get errors. you need change '$' to '$$' to solve the problem.It's a little boring.
And I notice that the jquery almost start with "$." or "$(", whitch is meanless in web.py template.
So, I add 2 lines that let template treat "$." "$(" as "$$." "$$(",and then both jquery and web.py work fine now.
