### PR TITLE
Add support for Tempita templates

### DIFF
--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -113,6 +113,30 @@ class render_mako:
         t = self._lookup.get_template(path)
         return t.render
 
+class render_tempita:
+    """Rendering interface to Tempita templates.
+    """
+
+    extensions = {
+        '.html': ('HTMLTemplate', 'text/html; charset=utf-8'),
+        '.xhtml': ('HTMLTemplate', 'application/xhtml+xml; charset=utf-8'),
+        '.txt': ('Template', 'text/plain'),
+    }
+
+    def __init__(self, directories):
+        import tempita
+        self.directories = directories
+
+    def __getattr__(self, name):
+        import tempita
+
+        for directory in self.directories:
+            for extension in self.extensions:
+                filename = os.path.join(directory, name + extension)
+                if os.path.exists(filename):
+                    template = getattr(tempita, self.extensions[extension][0]).from_filename(filename)
+                    return template.substitute
+
 class cache:
     """Cache for any rendering interface.
     

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -146,6 +146,8 @@ class render_tempita:
 
     def __getattr__(self, name):
         template = self._get_template(name)
+        if not template:
+            raise AttributeError('Template "%s" not found.' % name)
         def render(*args, **kwargs):
             import web
             if 'headers' in web.ctx and template.content_type:

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -132,8 +132,10 @@ class render_tempita:
         for directory in self.directories:
             for extension in self.extensions:
                 filename = os.path.join(directory, name + extension)
+                if not from_template:
+                    from_template = getattr(tempita, self.extensions[extension][0])
                 if os.path.exists(filename):
-                    template = getattr(tempita, self.extensions[extension][0]).from_filename(filename, get_template=self._get_template)
+                    template = from_template.from_filename(filename, get_template=self._get_template)
                     return template
 
     def __getattr__(self, name):

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -115,6 +115,11 @@ class render_mako:
 
 class render_tempita:
     """Rendering interface to Tempita templates.
+
+    Example:
+
+        render = render_tempita(['templates'])
+        render.hello(name='tempita')
     """
 
     extensions = {

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -137,9 +137,9 @@ class render_tempita:
         for directory in self.directories:
             for extension in self.extensions:
                 filename = os.path.join(directory, name + extension)
-                if not from_template:
-                    from_template = getattr(tempita, self.extensions[extension][0])
                 if os.path.exists(filename):
+                    if not from_template:
+                        from_template = getattr(tempita, self.extensions[extension][0])
                     template = from_template.from_filename(filename, get_template=self._get_template)
                     template.content_type = self.extensions[extension][1]
                     return template

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -127,15 +127,17 @@ class render_tempita:
         import tempita
         self.directories = directories
 
-    def __getattr__(self, name):
+    def _get_template(self, name, from_template=None):
         import tempita
-
         for directory in self.directories:
             for extension in self.extensions:
                 filename = os.path.join(directory, name + extension)
                 if os.path.exists(filename):
-                    template = getattr(tempita, self.extensions[extension][0]).from_filename(filename)
-                    return template.substitute
+                    template = getattr(tempita, self.extensions[extension][0]).from_filename(filename, get_template=self._get_template)
+                    return template
+
+    def __getattr__(self, name):
+        return self._get_template(name).substitute
 
 class cache:
     """Cache for any rendering interface.

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -141,10 +141,17 @@ class render_tempita:
                     from_template = getattr(tempita, self.extensions[extension][0])
                 if os.path.exists(filename):
                     template = from_template.from_filename(filename, get_template=self._get_template)
+                    template.content_type = self.extensions[extension][1]
                     return template
 
     def __getattr__(self, name):
-        return self._get_template(name).substitute
+        template = self._get_template(name)
+        def render(*args, **kwargs):
+            import web
+            if 'headers' in web.ctx and template.content_type:
+                web.header('Content-Type', template.content_type, unique=True)
+            return template.substitute(*args, **kwargs)
+        return render
 
 class cache:
     """Cache for any rendering interface.


### PR DESCRIPTION
Adds a `render_tempita` class in `web.contrib.templates` to allow [Tempita](http://pythonpaste.org/tempita/) templates to be used.
