### PR TITLE
Add optional support for sessions without client cookies

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -121,7 +121,6 @@ class Session(utils.ThreadedDict):
             web.setcookie(cookie_name, self.session_id, expires=-1, domain=cookie_domain)
 
     def _is_relative(self, url):
-        if url is None: return True
         split = urlsplit(url)
         return split[0] == '' and split[1] == ''
     
@@ -136,7 +135,7 @@ class Session(utils.ThreadedDict):
 
             # Add hidden input fields to forms
             for form in doc.iterfind('.//form'):
-                if self._is_relative(form.attrib.get('action', None)):
+                if 'action' not in form.attrib or self._is_relative(form.attrib['action']):
                     input = etree.Element('input', type='hidden', name=cookie_name, id=cookie_name, value=self.session_id)
                     form.append(input)
 

--- a/web/session.py
+++ b/web/session.py
@@ -5,6 +5,7 @@ Session Management
 
 import os, time, datetime, random, base64
 import os.path
+from cStringIO import StringIO
 from urlparse import urlsplit, urlunsplit
 try:
     import cPickle as pickle
@@ -164,14 +165,13 @@ class Session(object):
 
             if content_type == 'text/html':
                 tree = html
-                doc = html.document_fromstring(str(response))
-                ns = ''
             elif content_type in ('application/xhtml+xml', 'application/xml'):
                 tree = etree
-                doc = etree.fromstring(str(response))
-                ns = '{%s}' % doc.nsmap[None]
             else:
                 return response
+
+            doc = tree.parse(StringIO(str(response)))
+            ns = None in doc.getroot().nsmap and '{%s}' % doc.getroot().nsmap[None] or ''
 
             # Add hidden input fields to forms
             for form in doc.iterfind('.//%sform' % ns):

--- a/web/session.py
+++ b/web/session.py
@@ -4,6 +4,7 @@ Session Management
 """
 
 import os, time, datetime, random, base64, sys
+from urlparse import urlsplit, urlunsplit
 try:
     import cPickle as pickle
 except ImportError:
@@ -14,9 +15,6 @@ try:
 except ImportError:
     import sha
     sha1 = sha.new
-
-from lxml import html, etree
-from urlparse import urlsplit, urlunsplit
 
 import utils
 import webapi as web
@@ -128,6 +126,8 @@ class Session(utils.ThreadedDict):
         return split[0] == '' and split[1] == ''
     
     def _add_session(self, response):
+        from lxml import html, etree
+
         cookie_name = self._config.cookie_name
 
         # Only process response if client didn't provide a session cookie

--- a/web/session.py
+++ b/web/session.py
@@ -152,6 +152,12 @@ class Session(object):
         return split[0] == '' and split[1] == ''
     
     def _add_session(self, response):
+        cookie_name = self._config.cookie_name
+
+        # Only process response if client didn't provide a session cookie
+        if web.cookies().get(cookie_name):
+            return response
+
         from lxml import html, etree
         types = {
             'application/xhtml+xml': etree,
@@ -159,47 +165,42 @@ class Session(object):
             'text/html': html,
         }
 
-        cookie_name = self._config.cookie_name
+        content_type = None
+        for header, value in web.ctx.get('headers', []):
+            if header.lower() == 'content-type':
+                content_type = value.split(';')[0].lower()
+                content_type_params = dict((k.lower().strip(), v) for k,v in (part.split('=', 1) for part in value.split(';')[1:]))
 
-        # Only process response if client didn't provide a session cookie
-        if not web.cookies().get(cookie_name):
-            content_type = None
-            for header, value in web.ctx.get('headers', []):
-                if header.lower() == 'content-type':
-                    content_type = value.split(';')[0].lower()
-                    content_type_params = dict((k.lower().strip(), v) for k,v in (part.split('=', 1) for part in value.split(';')[1:]))
+        if content_type not in types:
+            return response
 
-            if content_type not in types:
-                return response
+        tree = types[content_type]
+        doc = tree.parse(StringIO(str(response)))
+        tostring_kwargs = {'encoding': content_type_params.get('charset', 'utf-8')}
+        if None in doc.getroot().nsmap:
+            ns = '{%s}' % doc.getroot().nsmap[None]
+            tostring_kwargs['xml_declaration'] = True
+        else:
+            ns = ''
 
-            tree = types[content_type]
-            doc = tree.parse(StringIO(str(response)))
-            tostring_kwargs = {'encoding': content_type_params.get('charset', 'utf-8')}
-            if None in doc.getroot().nsmap:
-                ns = '{%s}' % doc.getroot().nsmap[None]
-                tostring_kwargs['xml_declaration'] = True
-            else:
-                ns = ''
+        # Add hidden input fields to forms
+        for form in doc.iterfind('.//%sform' % ns):
+            if 'action' not in form.attrib or self._is_relative(form.attrib['action']):
+                input = etree.Element('input', type='hidden', name=cookie_name, id=cookie_name, value=self.session_id)
+                form.append(input)
 
-            # Add hidden input fields to forms
-            for form in doc.iterfind('.//%sform' % ns):
-                if 'action' not in form.attrib or self._is_relative(form.attrib['action']):
-                    input = etree.Element('input', type='hidden', name=cookie_name, id=cookie_name, value=self.session_id)
-                    form.append(input)
-
-            # Add query parameters to relative links
-            param = cookie_name + '=' + self.session_id
-            for a in doc.iterfind('.//%sa' % ns):
-                if 'href' in a.attrib and self._is_relative(a.attrib['href']):
-                    parts = list(urlsplit(a.attrib['href']))
-                    if len(parts[3]) == 0:
-                        parts[3] = param
-                    else:
-                        parts[3] += '&' + param
-                    a.attrib['href'] = urlunsplit(parts)
-                
-            return tree.tostring(doc, **tostring_kwargs)
-        return response
+        # Add query parameters to relative links
+        param = cookie_name + '=' + self.session_id
+        for a in doc.iterfind('.//%sa' % ns):
+            if 'href' in a.attrib and self._is_relative(a.attrib['href']):
+                parts = list(urlsplit(a.attrib['href']))
+                if len(parts[3]) == 0:
+                    parts[3] = param
+                else:
+                    parts[3] += '&' + param
+                a.attrib['href'] = urlunsplit(parts)
+            
+        return tree.tostring(doc, **tostring_kwargs)
             
     def _setcookie(self, session_id, expires='', **kw):
         cookie_name = self._config.cookie_name

--- a/web/session.py
+++ b/web/session.py
@@ -166,14 +166,15 @@ class Session(object):
             content_type = None
             for header, value in web.ctx.get('headers', []):
                 if header.lower() == 'content-type':
-                    content_type = value.lower().split(';')[0]
+                    content_type = value.split(';')[0].lower()
+                    content_type_params = dict((k.lower().strip(), v) for k,v in (part.split('=', 1) for part in value.split(';')[1:]))
 
             if content_type not in types:
                 return response
 
             tree = types[content_type]
             doc = tree.parse(StringIO(str(response)))
-            tostring_kwargs = {'encoding': 'utf-8'}
+            tostring_kwargs = {'encoding': content_type_params.get('charset', 'utf-8')}
             if None in doc.getroot().nsmap:
                 ns = '{%s}' % doc.getroot().nsmap[None]
                 tostring_kwargs['xml_declaration'] = True


### PR DESCRIPTION
If enabled and the client hasn't sent a session cookie, injects the session ID in the response by adding hidden form fields and adding query parameters to links. Requires lxml to process (X)HTML.
