### PR TITLE
Session Initializer Security Flaw Fix

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -5,6 +5,7 @@ Session Management
 
 import os, time, datetime, random, base64
 import os.path
+from copy import deepcopy
 try:
     import cPickle as pickle
 except ImportError:
@@ -109,7 +110,7 @@ class Session(object):
 
             if self._initializer:
                 if isinstance(self._initializer, dict):
-                    self.update(self._initializer)
+                    self.update(deepcopy(self._initializer))
                 elif hasattr(self._initializer, '__call__'):
                     self._initializer()
  


### PR DESCRIPTION
Updating session code to create a new copy of the initializer object with each new session. Caused major security issues at my company. This flaw allowed new users to log in as the last session used by Web.py.

I used deepcopy, because we set our initializer to a nested dictionary and normal copy() doesn't cut it.
