### PR TITLE
Changed docstring to fix formatting problem

### DIFF
--- a/web/net.py
+++ b/web/net.py
@@ -168,7 +168,8 @@ def htmlunquote(text):
     return text
     
 def websafe(val):
-    r"""Converts `val` so that it is safe for use in Unicode HTML.
+    r"""
+    Converts `val` so that it is safe for use in Unicode HTML.
 
         >>> websafe("<'&\">")
         u'&lt;&#39;&amp;&quot;&gt;'


### PR DESCRIPTION
Need to leave the very first line of the docstring blank to allow the markdown to render correctly whenever docstrings have multiple lines with examples.  A few functions have this issue.  If this is acceptable, I can go around and fix the rest of them up.

I considered changing makedoc.py to add the extra line but that wouldn't fix the inconsistency within within python with the help(<function_name>) variant, so decided it was better to just make the source docstrings consistent.
