### PR TITLE
Fixing regressing introduced by fix for issue 148

### DIFF
--- a/web/webapi.py
+++ b/web/webapi.py
@@ -422,7 +422,7 @@ def parse_cookies(http_cookie):
                     cookie.load(attr_value)
                 except Cookie.CookieError:
                     pass
-        cookies = dict((k, urllib.unquote(v.value)) for k, v in cookie.iteritems())
+        cookies = dict([(k, urllib.unquote(v.value)) for k, v in cookie.iteritems()])
     else:
         # HTTP_COOKIE doesn't have quotes, use fast cookie parsing
         cookies = {}


### PR DESCRIPTION
Tried building web.py against Python 2.3 and ran into the following:

```
$ python23 setup.py build
Traceback (most recent call last):
  File "setup.py", line 6, in ?
    from web import __version__
  File "~/webpy23/web/__init__.py", line 14, in ?
    import utils, db, net, wsgi, http, webapi, httpserver, debugerror
  File "~/webpy23/web/wsgi.py", line 8, in ?
    import http
  File "~/webpy23/web/http.py", line 16, in ?
    import net, utils, webapi as web
  File "~/webpy23/web/webapi.py", line 425
    cookies = dict((k, urllib.unquote(v.value)) for k, v in cookie.iteritems())
                                                  ^
SyntaxError: invalid syntax
```

Which I found was introduced by https://github.com/webpy/webpy/commit/c9053124d06614b84a0189e0a1cb2eb9f0351f99

Patch fixes syntax error, and enables the Hello World example on http://webpy.org to run, however almost 1 in 6 unit tests are currently failing:

```
$ python23 test/alltests.py > /dev/null
Unable to import sqlite3 (ignoring SqliteTest)
Unable to import pysqlite2.dbapi2 (ignoring SqliteTest_pysqlite2)
Unable to import psycopg2 (ignoring PostgresTest)
Unable to import psycopg (ignoring PostgresTest_psycopg)
No module named MySQLdb (ignoring MySQLTest)
Unable to import pgdb (ignoring PostgresTest_pgdb)
No module named DBUtils(ignoring testPooling)
..................................EE.E..EE.E...............................EEE..E........EEEE..............E.........................FE..EEEEEEEE
## Stack Traces Ommitted
----------------------------------------------------------------------
Ran 145 tests in 6.064s

FAILED (failures=1, errors=24)
```

This many failures suggests to me that web.py would not work very well on Python 2.3, which makes me wonder how important 2.3 compatibility really should be to the project - doesn't seem like people are missing it very much.
