### PR TITLE
paramstyle isn't set for FirebirdDB

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -1048,6 +1048,9 @@ class FirebirdDB(DB):
             del keywords['pw']
         keywords['database'] = keywords['db']
         del keywords['db']
+
+	self.paramstyle = db.paramstyle
+
         DB.__init__(self, db, keywords)
         
     def delete(self, table, where=None, using=None, vars=None, _test=False):


### PR DESCRIPTION
DB.insert was broken with FirebirdDB driver. Was falling back to
'pyformat' for paramstyle which kinterbasdb doesn't like. Paramstyle for
kinterbasdb needs to be 'qmark' which is already set on the DB object.
After adding this inserts now work.
