### PR TITLE
FirebirdDB __init__ needs to be fixed

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -1044,10 +1044,8 @@ class FirebirdDB(DB):
             db = None
             pass
         if 'pw' in keywords:
-            keywords['passwd'] = keywords['pw']
-            del keywords['pw']
-        keywords['database'] = keywords['db']
-        del keywords['db']
+            keywords['password'] = keywords.pop('pw')
+        keywords['database'] = keywords.pop('db')
 
         self.paramstyle = db.paramstyle
 


### PR DESCRIPTION
DB.insert was broken for FirebirdDB because the paramstyle was defaulting to 'pyformat'. Kinterbasdb expects 'qmark'. Setting paramstyle from the db object fixes this.

The password keyword is also wrong. Is being set as 'passwd', kinterbasdb looks for 'password'. Also re-wrote the keyword setting for 'database' and 'password' to use pop() instead of deleting the key manually. This keeps it consistent with how keywords are being set on the other drivers.
