### PR TITLE
Session 'initializer': Fixed Callable case of _initializer() in web.session.Session _load() 

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -114,7 +114,9 @@ class Session(object):
                 if isinstance(self._initializer, dict):
                     self.update(deepcopy(self._initializer))
                 elif hasattr(self._initializer, '__call__'):
-                    self._initializer()
+                    attrs = self._initializer()
+                    if attrs and type(attrs) is dict:
+                        self.update(deepcopy(attrs))
  
         self.ip = web.ctx.ip
 


### PR DESCRIPTION
in web.session.Session _load()

TLDR; Fixed _initialize for callable case. If initializer kwarg present, allow _initializer() to return dict which can be used to update self, i.e. for Session (assuming _initializer returns a dict) self.update(deepcopy(_initializer())) 

Long explanation:
Updated Session._load(self), within the logic for self._initializer (determining if _initializer is present, and if so whether it is a dict versus callable func). If _initializer is callable, right now there is no way to update the Session's attributes (like one could do if they just provide initialize=some_dictionary). One bad solution is to require _initializer take an argument of self. The better solution (implemented here) is for _load() to allow/expect the callable case of _initializer to return a dictionary which can be used to update the Session's attributes, i.e. self.update(_initializer())
