### PR TITLE
Add support for sqlite to dburl2dict utility function

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -1143,8 +1143,6 @@ def dburl2dict(url):
         {'user': 'james', 'host': 'serverfarm.example.net', 'db': 'mygreatdb', 'pw': 'day', 'dbn': 'postgres'}
         >>> dburl2dict('postgres://james:d%40y@serverfarm.example.net/mygreatdb')
         {'user': 'james', 'host': 'serverfarm.example.net', 'db': 'mygreatdb', 'pw': 'd@y', 'dbn': 'postgres'}
-        >>> dburl2dict('postgres://james:d%40y@serverfarm.example.net/mygreatdb')
-        {'user': 'james', 'host': 'serverfarm.example.net', 'db': 'mygreatdb', 'pw': 'd@y', 'dbn': 'postgres'}
         >>> dburl2dict('sqlite:///mygreatdb.db')
         {'db': 'mygreatdb.db', 'dbn': 'sqlite'}
         >>> dburl2dict('sqlite:////absolute/path/mygreatdb.db')

--- a/web/db.py
+++ b/web/db.py
@@ -1143,20 +1143,33 @@ def dburl2dict(url):
         {'user': 'james', 'host': 'serverfarm.example.net', 'db': 'mygreatdb', 'pw': 'day', 'dbn': 'postgres'}
         >>> dburl2dict('postgres://james:d%40y@serverfarm.example.net/mygreatdb')
         {'user': 'james', 'host': 'serverfarm.example.net', 'db': 'mygreatdb', 'pw': 'd@y', 'dbn': 'postgres'}
+        >>> dburl2dict('postgres://james:d%40y@serverfarm.example.net/mygreatdb')
+        {'user': 'james', 'host': 'serverfarm.example.net', 'db': 'mygreatdb', 'pw': 'd@y', 'dbn': 'postgres'}
+        >>> dburl2dict('sqlite:///mygreatdb.db')
+        {'db': 'mygreatdb.db', 'dbn': 'sqlite'}
+        >>> dburl2dict('sqlite:////absolute/path/mygreatdb.db')
+        {'db': '/absolute/path/mygreatdb.db', 'dbn': 'sqlite'}
     """
     dbn, rest = url.split('://', 1)
-    user, rest = rest.split(':', 1)
-    pw, rest = rest.split('@', 1)
-    if ':' in rest:
-        host, rest = rest.split(':', 1)
-        port, rest = rest.split('/', 1)
+    if rest.startswith('/'):
+        _, rest = rest.split('/', 1)
+        user = pw = host = port = ''
     else:
-        host, rest = rest.split('/', 1)
-        port = None
+        user, rest = rest.split(':', 1)
+        pw, rest = rest.split('@', 1)
+        if ':' in rest:
+            host, rest = rest.split(':', 1)
+            port, rest = rest.split('/', 1)
+        else:
+            host, rest = rest.split('/', 1)
+            port = None
     db = rest
     
     uq = urllib.unquote
     out = dict(dbn=dbn, user=uq(user), pw=uq(pw), host=uq(host), db=uq(db))
+    if not user: out.pop('user')
+    if not pw: out.pop('pw')
+    if not host: out.pop('host')
     if port: out['port'] = port
     return out
 


### PR DESCRIPTION
With this pull request I'm trying to support `sqlite` database urls inside the utility function `dburl2dict`.

As you can see from the patch, I decided to initialize `user`, `pw`, `host` and `port` to empty strings,  then to pop corresponding items from the output dictionary before returning it.

Another solution would have been to initialize `out` with the sole mandatory fields (i.e. `dbn` and `db`) and fill optional ones if set, but in this case all the existing doctests should have been rewritten as well (the keys insertion ordering in the output dictionary would have been different).
