### PR TITLE
Added support for session storage in Redis

### DIFF
--- a/test/doctests.py
+++ b/test/doctests.py
@@ -7,15 +7,15 @@ def suite():
         "web.application",
         "web.db",
         "web.form",
-        "web.http", 
-        "web.net", 
+        "web.http",
+        "web.net",
         "web.session",
         "web.template",
-        "web.utils", 
-#        "web.webapi", 
-#        "web.wsgi", 
+        "web.utils",
+#        "web.webapi",
+#        "web.wsgi",
     ]
     return webtest.doctest_suite(modules)
-    
+
 if __name__ == "__main__":
     webtest.main()

--- a/test/session.py
+++ b/test/session.py
@@ -10,7 +10,7 @@ class SessionTest(webtest.TestCase):
             def GET(self):
                 session.count += 1
                 return str(session.count)
-        
+
         class reset(app.page):
             def GET(self):
                 session.kill()
@@ -25,17 +25,17 @@ class SessionTest(webtest.TestCase):
             path = "/session/(.*)"
             def GET(self, name):
                 return session[name]
-                
+
         self.app = app
         self.session = session
-        
+
     def make_session(self, app):
         dir = tempfile.mkdtemp()
         store = web.session.DiskStore(tempfile.mkdtemp())
         return web.session.Session(app, store, {'count': 0})
-        
+
     def testSession(self):
-        b = self.app.browser() 
+        b = self.app.browser()
         self.assertEquals(b.open('/count').read(), '1')
         self.assertEquals(b.open('/count').read(), '2')
         self.assertEquals(b.open('/count').read(), '3')
@@ -45,9 +45,9 @@ class SessionTest(webtest.TestCase):
     def testParallelSessions(self):
         b1 = self.app.browser()
         b2 = self.app.browser()
-        
+
         b1.open('/count')
-        
+
         for i in range(1, 10):
             self.assertEquals(b1.open('/count').read(), str(i+1))
             self.assertEquals(b2.open('/count').read(), str(i))
@@ -56,7 +56,7 @@ class SessionTest(webtest.TestCase):
         b = self.app.browser()
         self.assertEquals(b.open('/count').read(), '1')
         self.assertEquals(b.open('/count').read(), '2')
-        
+
         cookie = b.cookiejar._cookies['0.0.0.0']['/']['webpy_session_id']
         cookie.value = '/etc/password'
         self.assertEquals(b.open('/count').read(), '1')
@@ -72,7 +72,7 @@ class DBSessionTest(SessionTest):
     def make_session(self, app):
         db = webtest.setup_database("sqlite", "sqlite3")
         #db.printing = True
-        db.query("" 
+        db.query(""
             + "CREATE TABLE session ("
             + "    session_id char(128) unique not null,"
             + "    atime timestamp default (datetime('now','utc')),"
@@ -85,6 +85,11 @@ class DBSessionTest(SessionTest):
         # there might be some error with the current connection, delete from a new connection
         self.db = webtest.setup_database("sqlite","sqlite3")
         self.db.query('DROP TABLE session')
-         
+
+class RedisSessionTest(SessionTest):
+    def make_session(self, app):
+        import redis
+
+
 if __name__ == "__main__":
     webtest.main()

--- a/test/session.py
+++ b/test/session.py
@@ -87,8 +87,16 @@ class DBSessionTest(SessionTest):
         self.db.query('DROP TABLE session')
 
 class RedisSessionTest(SessionTest):
+    """Session test with redis store"""
     def make_session(self, app):
         import redis
+        self.redis_conn = redis.Redis(host='localhost', port=6379, db=0)
+        store = web.session.RedisStore(self.redis_conn)
+        return web.session.Session(app, store, {'count': 0})
+
+    def tearDown(self):
+        self.redis_conn = None
+
 
 
 if __name__ == "__main__":

--- a/web/session.py
+++ b/web/session.py
@@ -19,7 +19,6 @@ except ImportError:
 
 import utils
 import webapi as web
-import redis
 
 __all__ = [
     'Session', 'SessionExpired',
@@ -355,24 +354,23 @@ class ShelfStore:
                 del self[k]
 
 class RedisStore(Store):
-    """Use a Redis Instance as a Session Store
+    """
+    Use a Redis Instance as a Session Store. Uses the redis-py library as a
+    Python wrapper for a Redis instance. https://github.com/andymccurdy/redis-py
+
+    import redis
+
     """
 
-    def __init__(self, redis_host, redis_password, redis_port,
-                 redis_db, session_key_prefix="web::session::key::%s"):
-        self.redis_host = redis_host
-        self.redis_password = redis_password
-        self.redis_port = redis_port
-        self.redis_db = redis_db
-
-        self.connection_pool = redis.ConnectionPool(host=self.redis_host,
-                            password=self.redis_password, port=self.redis_port,
-                            db=self.redis_db)
-
+    def __init__(self, redis_conn, session_key_prefix="web::session::key::%s"):
+        """
+        redis - The redis connection object.
+        session_key_prefix - The prefix of the unique identifier for each
+                             session stored. This is used for namespacing
+                             in redis.
+        """
         self.session_key_prefix = session_key_prefix
-
-        self.redis = redis.Redis(connection_pool=self.connection_pool)
-        super(RedisStore, self).__init__()
+        self.redis = redis_conn
 
     def __contains__(self, key):
         return self.redis.exists(session_key_prefix % key)

--- a/web/session.py
+++ b/web/session.py
@@ -373,28 +373,28 @@ class RedisStore(Store):
         self.redis = redis_conn
 
     def __contains__(self, key):
-        return self.redis.exists(session_key_prefix % key)
+        return self.redis.exists(self.session_key_prefix % key)
 
     def __getitem__(self, key):
-        session_key = session_key_prefix % key
+        session_key = self.session_key_prefix % key
         data = self.redis.get(session_key)
         if data:
-            self.redis.expire(session_key, web.webapi.config.session_parameters.timeout)
+            self.redis.expire(session_key, web.config.session_parameters.timeout)
             decoded_data = self.decode(data)
             return decoded_data
         else:
             raise KeyError
 
     def __setitem__(self, key, value):
-        session_key = session_key_prefix % key
+        session_key = self.session_key_prefix % key
         encoded_value = self.encode(value)
         pipe = self.redis.pipeline()
         pipe.set(session_key, encoded_value)
-        pipe.expire(session_key, web.webapi.config.session_parameters.timeout)
+        pipe.expire(session_key, web.config.session_parameters.timeout)
         pipe.execute()
 
     def __delitem__(self, key):
-        session_key = session_key_prefix % key
+        session_key = self.session_key_prefix % key
         self.redis.delete(session_key)
 
     def cleanup(self, timeout):

--- a/web/session.py
+++ b/web/session.py
@@ -364,13 +364,13 @@ class RedisStore(Store):
 
     def __init__(self, redis_conn, session_key_prefix="web::session::key::%s"):
         """
-        redis - The redis connection object.
+        redis_conn - The redis connection object.
         session_key_prefix - The prefix of the unique identifier for each
                              session stored. This is used for namespacing
                              in redis.
         """
-        self.session_key_prefix = session_key_prefix
         self.redis = redis_conn
+        self.session_key_prefix = session_key_prefix
 
     def __contains__(self, key):
         return self.redis.exists(self.session_key_prefix % key)


### PR DESCRIPTION
Added RedisStore to web.session to allow sessions to be stored in Redis. Added doctests for testing purposes too. 

This requires the redis-py library, which can be found at https://github.com/andymccurdy/redis-py/.

I hope that I've followed the appropriate style and coding conventions. 
