### PR TITLE
allow the optional use of a path-to-class dict instead of regex-matching all paths, workaround Issue #214 and general perf improvement

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -110,7 +110,8 @@ class application:
     def _cleanup(self):
         # Threads can be recycled by WSGI servers.
         # Clearing up all thread-local state to avoid interefereing with subsequent requests.
-        utils.ThreadedDict.clear_all()
+        if hasattr(utils.ThreadedDict, 'clear_all'):
+            utils.ThreadedDict.clear_all()
 
     def init_mapping(self, mapping):
         self.mapping = list(utils.group(mapping, 2))


### PR DESCRIPTION
If you have a constant (no regex matching necessary) set of paths to map, you can now add use_path_dict=True to your:
app = web.application(urls, globals(), use_path_dict=True)
call to use a dict of something like:
{'web.ctx.path-1': class_to_handle_path-1}

rather than avoiding the regex matching against all paths for every call.

While this will have a tiny perf boost, its main benefit is avoiding the non-thread-safe memoization of re_compile discussed in Issue #214

This should be completely transparent and backwards compatible for any users requiring regex matching of paths...
