### PR TITLE
added a method to renew session id on auth to prevent session fixation

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -182,6 +182,10 @@ class Session(object):
         """Kill the session, make it no longer available"""
         del self.store[self.session_id]
         self._killed = True
+        
+    def renew_session_id(self):
+        """Renew the session id to prevent session fixation attacks"""
+        self.session_id = self._generate_session_id()
 
 class Store:
     """Base class for session stores"""


### PR DESCRIPTION
call this method during user authentication to prevent session fixation
attacks. the old, unauthenticated session id is re-generated in order to
start a "new" session after login
