### PR TITLE
Fixed #191, #182, #83: DiskStore concurrency issue

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -253,13 +253,15 @@ class DiskStore(Store):
 
     def __setitem__(self, key, value):
         path = self._get_path(key)
-        pickled = self.encode(value)    
+        pickled = self.encode(value)
         try:
-            f = open(path, 'w')
+            tname = path+"."+threading.current_thread().getName()
+            f = open(tname, 'w')
             try:
                 f.write(pickled)
-            finally: 
+            finally:
                 f.close()
+                os.rename(tname, path) # atomary operation
         except IOError:
             pass
 


### PR DESCRIPTION
See #191, #182, #83
DiskStore.**setitem** is not atomary and a host of errors can be thrown under
load. This method has been made threadsafe.
