### PR TITLE
Fixed #191, #182, #83: DiskStore concurrency issue

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -5,6 +5,7 @@ Session Management
 
 import os, time, datetime, random, base64
 import os.path
+import threading
 from copy import deepcopy
 try:
     import cPickle as pickle


### PR DESCRIPTION
See #191, #182, #83
DiskStore.**setitem** is not atomary and a host of errors can be thrown under
load. This method has been made threadsafe.
