### PR TITLE
Support '204 No Content' status code

### DIFF
--- a/web/webapi.py
+++ b/web/webapi.py
@@ -11,9 +11,9 @@ __all__ = [
     "ctx", 
     "HTTPError", 
 
-    # 200, 201, 202
-    "OK", "Created", "Accepted",    
-    "ok", "created", "accepted",
+    # 200, 201, 202, 204
+    "OK", "Created", "Accepted", "NoContent",    
+    "ok", "created", "accepted", "nocontent",
     
     # 301, 302, 303, 304, 307
     "Redirect", "Found", "SeeOther", "NotModified", "TempRedirect", 
@@ -65,6 +65,7 @@ def _status_code(status, data=None, classname=None, docstring=None):
 ok = OK = _status_code("200 OK", data="")
 created = Created = _status_code("201 Created")
 accepted = Accepted = _status_code("202 Accepted")
+nocontent = NoContent = _status_code("204 No Content")
 
 class Redirect(HTTPError):
     """A `301 Moved Permanently` redirect."""


### PR DESCRIPTION
Writing REST APIs often requires one end-point to return an empty response even if the client is expecting a JSON/XML object.

Instead of making the server return an explicit _empty_ object (e.g. `{}`), a better solution is to send a '204 No Content' message back to the client.

On stackoverflow I found a small discussion on the subject: 
http://stackoverflow.com/questions/11970962/valid-json-in-response
