### PR TITLE
Enable exception handling inside application processors

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -231,22 +231,22 @@ class application:
         
     def handle_with_processors(self):
         def process(processors):
-            try:
-                if processors:
-                    p, processors = processors[0], processors[1:]
-                    return p(lambda: process(processors))
-                else:
-                    return self.handle()
-            except web.HTTPError:
-                raise
-            except (KeyboardInterrupt, SystemExit):
-                raise
-            except:
-                print >> web.debug, traceback.format_exc()
-                raise self.internalerror()
+            if processors:
+                p, processors = processors[0], processors[1:]
+                return p(lambda: process(processors))
+            else:
+                return self.handle()
         
-        # processors must be applied in the resvere order. (??)
-        return process(self.processors)
+        try:
+            # processors must be applied in the resvere order. (??)
+            return process(self.processors)
+        except web.HTTPError:
+            raise
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            print >> web.debug, traceback.format_exc()
+            raise self.internalerror()
                         
     def wsgifunc(self, *middleware):
         """Returns a WSGI-compatible function for this application."""


### PR DESCRIPTION
Prior to this patch, to manage certain kind of exceptions not to send a '500 Internal Error' message back to the client, one had to subclass web.application and change the behaviour of the method `handle_with_processors`.

The problem with the previous implementation was that each application processor and in turn the request handler were called inside a try-catch block:  this way, exceptions thrown in the _real_ handler ended up being caught by the first try-catch block found traversing the stack (i.e. the one around the call to `self.handle`).

With this patch only the call `process(processors)` has been surrounded by a try-catch block and consequently application processors are now free to manage raised exceptions.
