### PR TITLE
Set default cookie_path to '/'

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -28,7 +28,7 @@ __all__ = [
 web.config.session_parameters = utils.storage({
     'cookie_name': 'webpy_session_id',
     'cookie_domain': None,
-    'cookie_path' : None,
+    'cookie_path' : '/',
     'timeout': 86400, #24 * 60 * 60, # 24 hours in seconds
     'ignore_expiry': True,
     'ignore_change_ip': True,


### PR DESCRIPTION
When deploying with mod_wsgi, every request will generate a new session by default. The session sample in the cookbook dosn't work at all. An optional solution is set 'web.config.session_parameters['cookie_path']' before using session. Set default cookie_path will simply solve this issue.
