### PR TITLE
Matching unicode in URL patterns.

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -2,6 +2,7 @@
 Web application
 (from web.py)
 """
+from re import UNICODE
 import webapi as web
 import webapi, wsgi, utils
 import debugerror
@@ -476,7 +477,7 @@ class application:
             elif isinstance(what, basestring):
                 what, result = utils.re_subm('^' + pat + '$', what, value)
             else:
-                result = utils.re_compile('^' + pat + '$').match(value)
+                result = utils.re_compile('^' + pat + '$').match(value, UNICODE)
                 
             if result: # it's a match
                 return what, [x for x in result.groups()]
@@ -588,7 +589,7 @@ class subdomain_application(application):
             if isinstance(what, basestring):
                 what, result = utils.re_subm('^' + pat + '$', what, value)
             else:
-                result = utils.re_compile('^' + pat + '$').match(value)
+                result = utils.re_compile('^' + pat + '$',UNICODE).match(value)
 
             if result: # it's a match
                 return what, [x for x in result.groups()]

--- a/web/utils.py
+++ b/web/utils.py
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 import re, sys, time, threading, itertools, traceback, os
-
+from re import UNICODE
 try:
     import subprocess
 except ImportError: 
@@ -528,7 +528,7 @@ def re_subm(pat, repl, string):
         >>> m.groups()
         ('oooooo',)
     """
-    compiled_pat = re_compile(pat)
+    compiled_pat = re_compile(pat,UNICODE)
     proxy = _re_subm_proxy()
     compiled_pat.sub(proxy.__call__, string)
     return compiled_pat.sub(repl, string), proxy.match
@@ -1324,7 +1324,7 @@ def to36(q):
     return "".join(converted) or '0'
 
 
-r_url = re_compile('(?<!\()(http://(\S+))')
+r_url = re_compile('(?<!\()(http://(\S+))', UNICODE)
 def safemarkdown(text):
     """
     Converts text to HTML following the rules of Markdown, but blocking any


### PR DESCRIPTION
web.py is very clever at translating unicode urls, but then uses ascii-only regexes to (not) route them. These little changes in application.py and utils.py allow proper matching of unicode urls. 
