### PR TITLE
Missing body for NoMethod error handler 

### DIFF
--- a/web/webapi.py
+++ b/web/webapi.py
@@ -171,7 +171,8 @@ def NotFound(message=None):
 notfound = NotFound
 
 class NoMethod(HTTPError):
-    """A `405 Method Not Allowed` error."""
+    """`405 Method Not Allowed` error."""
+    message = "method not allowed"
     def __init__(self, cls=None):
         status = '405 Method Not Allowed'
         headers = {}
@@ -182,8 +183,7 @@ class NoMethod(HTTPError):
             methods = [method for method in methods if hasattr(cls, method)]
 
         headers['Allow'] = ', '.join(methods)
-        data = None
-        HTTPError.__init__(self, status, headers, data)
+        HTTPError.__init__(self, status, headers, self.message)
         
 nomethod = NoMethod
 


### PR DESCRIPTION
Added a reasonable message to NoMethod() to make it behave like the other error messages.
