### PR TITLE
Fix validip6addr bug on Windows

### DIFF
--- a/web/net.py
+++ b/web/net.py
@@ -31,7 +31,7 @@ def validip6addr(address):
     """
     try:
         socket.inet_pton(socket.AF_INET6, address)
-    except socket.error:
+    except (socket.error, AttributeError):
         return False
 
     return True


### PR DESCRIPTION
On installing web.py afresh from git on Windows 2.7.2 the tutorial fails with:

```
U:\code\usage\usage> python code.py 3333
Traceback (most recent call last):
  File "code.py", line 13, in <module>
    app.run()
  File "C:\Python27\lib\site-packages\web\application.py", line 313, in run
    return wsgi.runwsgi(self.wsgifunc(*middleware))
  File "C:\Python27\lib\site-packages\web\wsgi.py", line 55, in runwsgi
    server_addr = validip(listget(sys.argv, 1, ''))
  File "C:\Python27\lib\site-packages\web\net.py", line 108, in validip
    if validip6addr(ip): return (ip,port)
  File "C:\Python27\lib\site-packages\web\net.py", line 33, in validip6addr
    socket.inet_pton(socket.AF_INET6, address)
AttributeError: 'module' object has no attribute 'inet_pton'
U:\code\usage\usage> python
Enthought Python Distribution -- www.enthought.com
Version: 7.2-2 (32-bit)

Python 2.7.2 |EPD 7.2-2 (32-bit)| (default, Sep 14 2011, 11:02:05) [MSC v.1500 32 bit (Intel)] on win32
Type "packages", "demo" or "enthought" for more information.
>>> import socket
>>> socket.inet_pton()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'inet_pton'
>>>
```

The error is that web/net.py is missing the correct exception at line 34. This PR fixes that.
