### PR TITLE
Bugfix: Escape angle brackets in Template.__init__ default value

### DIFF
--- a/web/template.py
+++ b/web/template.py
@@ -840,7 +840,7 @@ class Template(BaseTemplate):
     }
     globals = {}
     
-    def __init__(self, text, filename='<template>', filter=None, globals=None, builtins=None, extensions=None):
+    def __init__(self, text, filename='&lt;template&gt;', filter=None, globals=None, builtins=None, extensions=None):
         self.extensions = extensions or []
         text = Template.normalize_text(text)
         code = self.compile_template(text, filename)


### PR DESCRIPTION
Fixes webpy/webpy#230 and potentially cause for broken HTML at http://webpy.org/docs/0.3/api#web.template
