### PR TITLE
Auto-extend session lifetime in DiskStore

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -246,6 +246,7 @@ class DiskStore(Store):
     def __getitem__(self, key):
         path = self._get_path(key)
         if os.path.exists(path): 
+            os.utime(path, None)
             pickled = open(path).read()
             return self.decode(pickled)
         else:


### PR DESCRIPTION
If you use DiskStore for sessions (provided they are checked against expiration), they expire 'timeout' after the session was created, not last accessed (which is the behaviour of DBStore). So I added os.utime() [a.k.a. "python touch"] as similar operation to what is in DBStore:

self.db.update(self.table, where="session_id=$key", atime=now, vars=locals())

I hope this commit makes the two storages more similar in behaviour.
