### PR TITLE
using safestr in web.form.Dropdown._render_option

### DIFF
--- a/web/form.py
+++ b/web/form.py
@@ -255,11 +255,11 @@ class Dropdown(Input):
 
         value = utils.safestr(value)
         if isinstance(self.value, (tuple, list)):
-            self.value = [utils.safestr(x) for x in self.value]
+            s_value = [utils.safestr(x) for x in self.value]
         else:
-            self.value = utils.safestr(self.value)
+            s_value = utils.safestr(self.value)
         
-        if self.value == value or (isinstance(self.value, list) and value in self.value):
+        if s_value == value or (isinstance(s_value, list) and value in s_value):
             select_p = ' selected="selected"'
         else:
             select_p = ''


### PR DESCRIPTION
Convert to str (using safestr) before value comparison.

Old behavior (notice the second example):

``` python
d = Dropdown(name='a', args=[1,2,3], value=1)
>>> d.render()
u'<select id="a" name="a">\n  <option selected="selected" value="1">1</option>\n  <option value="2">2</option>\n  <option value="3">3</option>\n</select>\n'
>>> 
>>> d = Dropdown(name='a', args=[1,2,3], value='1')
>>> d.render()
u'<select id="a" name="a">\n  <option value="1">1</option>\n  <option value="2">2</option>\n  <option value="3">3</option>\n</select>\n'
>>> 
```

New behavior (also notice the second example):

``` python
>>> d = Dropdown(name='a', args=[1,2,3], value=1)
>>> d.render()
u'<select id="a" name="a">\n  <option selected="selected" value="1">1</option>\n  <option value="2">2</option>\n  <option value="3">3</option>\n</select>\n'
>>> 
>>> d = Dropdown(name='a', args=[1,2,3], value='1')
>>> d.render()
u'<select id="a" name="a">\n  <option selected="selected" value="1">1</option>\n  <option value="2">2</option>\n  <option value="3">3</option>\n</select>\n'
>>> 
```
