### PR TITLE
modernizing Templetor SafeVisitor code using new ast module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .DS_Store
+web.py.egg-info

--- a/web/net.py
+++ b/web/net.py
@@ -19,6 +19,8 @@ import socket
 def validip6addr(address):
     """
     Returns True if `address` is a valid IPv6 address.
+    catch AttributeError - python does not handle ipv6 errors normally
+    https://github.com/webpy/webpy/pull/195
 
         >>> validip6addr('::')
         True
@@ -31,7 +33,7 @@ def validip6addr(address):
     """
     try:
         socket.inet_pton(socket.AF_INET6, address)
-    except socket.error:
+    except (socket.error, AttributeError):
         return False
 
     return True

--- a/web/template.py
+++ b/web/template.py
@@ -1151,18 +1151,21 @@ class SafeVisitor(ast.NodeVisitor):
         super(SafeVisitor, self).generic_visit(node)
 
     def visit_Assign(self, node):
-        self.check_assign_node(node)
+        self.check_assign_targets(node)
 
     def visit_AugAssign(self, node):
-        self.check_assign_node(node)
+        self.check_assign_target(node)
 
-    def check_assign_node(self, node):
+    def check_assign_targets(self, node):
         for target in node.targets:
-            targetname = type(target).__name__
-            if targetname == "Attribute":
-                attrname = self.get_node_attr(target)
-                self.fail_attribute(target, attrname)
+            self.check_assign_target(target)
         super(SafeVisitor, self).generic_visit(node)
+
+    def check_assign_target(self, targetnode):
+        targetname = type(targetnode).__name__
+        if targetname == "Attribute":
+            attrname = self.get_node_attr(targetnode)
+            self.fail_attribute(targetnode, attrname)
 
     # failure modes
     def fail_name(self, node, nodename):

--- a/web/utils.py
+++ b/web/utils.py
@@ -882,11 +882,11 @@ def datestr(then, now=None):
         ... }.iteritems():
         ...     assert datestr(d, now=d+t) == v
         >>> datestr(datetime(1970, 1, 1), now=d)
-        'January  1'
+        'January 01'
         >>> datestr(datetime(1969, 1, 1), now=d)
-        'January  1, 1969'
+        'January 01, 1969'
         >>> datestr(datetime(1970, 6, 1), now=d)
-        'June  1, 1970'
+        'June 01, 1970'
         >>> datestr(None)
         ''
     """

--- a/web/utils.py
+++ b/web/utils.py
@@ -99,17 +99,28 @@ def storify(mapping, *requireds, **defaults):
     `storage({'a':1, 'b':2, 'c':3})`.
     
     If a `storify` value is a list (e.g. multiple values in a form submission), 
-    `storify` returns the last element of the list, unless the key appears in 
+    `storify` returns the first element of the list, unless the key appears in
     `defaults` as a list. Thus:
     
         >>> storify({'a':[1, 2]}).a
-        2
+        1
         >>> storify({'a':[1, 2]}, a=[]).a
         [1, 2]
         >>> storify({'a':1}, a=[]).a
         [1]
         >>> storify({}, a=[]).a
         []
+
+    Note: `storify` used to return the *last* element of the list, but this is a less
+    useful default.  Consider a common workflow editing values in some kind of storage:
+
+        #. user clicks a hyperlink to /edit/?a=1&b=2 to edit attributes on object A1
+        #. GET populates a form with hidden value `a` of 1 and textbox `b`, filled with 2
+        #. user changes the value of `b` to be 3 and submits
+        #. expects object A1 to update `b` to be 3
+        #. `web.webapi.rawinput()` returns a list b=[3, 2]
+        #. `storify` used to take the last value, 2, which was from the GET
+        #. what we actually want is the first value, 3, from the POST
     
     Similarly, if the value has a `value` attribute, `storify will return _its_
     value, unless the key appears in `defaults` as a dictionary.
@@ -156,7 +167,7 @@ def storify(mapping, *requireds, **defaults):
             if isinstance(defaults.get(key), list):
                 value = [getvalue(x) for x in value]
             else:
-                value = value[-1]
+                value = value[0]
         if not isinstance(defaults.get(key), dict):
             value = getvalue(value)
         if isinstance(defaults.get(key), list) and not isinstance(value, list):


### PR DESCRIPTION
I noticed that some of the newer dictionary comprehensions were getting denied by SafeVisitor() .. digging in, this was b/c they were not in the allowed node WHITELIST.  Since we are only looking for a few very recognizable types of "unsafe" nodes, it seems more maintainable to make this a BLACKLIST.  The new ast module also provides a NodeVisitor class now, which allows us to clean up this SafeVisitor class a little bit, and make it Py3 compatable.  Also, the full ast module is available in jython: http://www.jython.org/docs/library/ast.html.  
