### PR TITLE
Python 2.5 no longer supported on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
 #  - "3.1"


### PR DESCRIPTION
Which will fix the broken build status indicator