### PR TITLE
Make re-compile thread-safe (Issue #214)

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -483,11 +483,13 @@ class Memoize:
         self.expires = expires
         self.background = background
         self.running = {}
+        self.running_lock = threading.Lock()
     
     def __call__(self, *args, **keywords):
         key = (args, tuple(keywords.items()))
-        if not self.running.get(key):
-            self.running[key] = threading.Lock()
+        with self.running_lock:
+            if not self.running.get(key):
+                self.running[key] = threading.Lock()
         def update(block=False):
             if self.running[key].acquire(block):
                 try:
@@ -506,7 +508,7 @@ class Memoize:
 
 memoize = Memoize
 
-re_compile = memoize(re.compile) #@@ threadsafe?
+re_compile = memoize(re.compile)
 re_compile.__doc__ = """
 A memoized version of re.compile.
 """


### PR DESCRIPTION
Under heavy load, we sometimes see the following error (see issue #214)
Exception in thread Thread-328:
  File "/pkg/lib/python2.7/site-packages/web/utils.py", line 500, in **call**
    update(block=True)
  File "/pkg/lib/python2.7/site-packages/web/utils.py", line 497, in update
    self.running[key].release()
error: release unlocked lock

This can happen when there is a thread-switch between the test and creation
of self.running[key]. In this patch we acquire a lock first
to make the test+create atomic.
