### PR TITLE
Fix data loss issue with transaction error handling

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -471,13 +471,17 @@ class Transaction:
 
     def commit(self):
         if len(self.ctx.transactions) > self.transaction_count:
-            self.engine.do_commit()
-            self.ctx.transactions = self.ctx.transactions[:self.transaction_count]
+            try:
+                self.engine.do_commit()
+            finally:
+                self.ctx.transactions = self.ctx.transactions[:self.transaction_count]
 
     def rollback(self):
         if len(self.ctx.transactions) > self.transaction_count:
-            self.engine.do_rollback()
-            self.ctx.transactions = self.ctx.transactions[:self.transaction_count]
+            try:
+                self.engine.do_rollback()
+            finally:
+                self.ctx.transactions = self.ctx.transactions[:self.transaction_count]
 
 class DB: 
     """Database"""


### PR DESCRIPTION
If a database error (for example a connection error) occurs during the `self.engine.do_commit()` or `self.engine.do_rollback()` calls here, then the transaction won't be popped off the transaction stack.

Note that I'm using web.py with connection pooling (DBUtils), which are good for fast, long-running connections. So what was happening was all the subsequent database transactions would _appear_ to succeed, but actually were never committed because there was still something on the transaction stack at the end of the next commit.

This fix corrects the issue. An alternative (I think) would be to simply swap the order of the two lines, ensuring the `self.ctx.transactions` update happens first and hence always happens.
