### PR TITLE
added ctx.db.close() method to class destructor ref issue: #251

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -925,6 +925,10 @@ class DB:
     def transaction(self): 
         """Start a transaction."""
         return Transaction(self.ctx)
+
+    def __del__(self):
+        """faster close of database connection"""
+        self.ctx.db.close()
     
 class PostgresDB(DB): 
     """Postgres driver."""


### PR DESCRIPTION
per discussion in issue: #251

This is how I patched db.py to explicitly close database connections on class destruction; which solves the issue with MySQL abandoned clients while waiting for garbage collection.

I was using multi-threading and opening hundreds of database connections at a time, which would crash MYSQL after a couple rounds
