### PR TITLE
Reject route matches ending with newlines

### DIFF
--- a/test/application.py
+++ b/test/application.py
@@ -92,6 +92,20 @@ class ApplicationTest(webtest.TestCase):
         response = app.request('/b/foo?x=2')
         self.assertEquals(response.status, '301 Moved Permanently')
         self.assertEquals(response.headers['Location'], 'http://0.0.0.0:8080/hello/foo?x=2')
+
+    def test_routing(self):
+        urls = (
+            "/foo", "foo"
+        )
+
+        class foo:
+            def GET(self):
+                return "foo"
+
+        app = web.application(urls, {"foo": foo})
+
+        self.assertEquals(app.request('/foo\n').data, b'not found')
+        self.assertEquals(app.request('/foo').data, b'foo')
         
     def test_subdirs(self):
         urls = (

--- a/web/application.py
+++ b/web/application.py
@@ -500,9 +500,9 @@ class application:
                 else:
                     continue
             elif isinstance(what, string_types):
-                what, result = utils.re_subm('^' + pat + '$', what, value)
+                what, result = utils.re_subm(r'^%s\Z' % (pat,), what, value)
             else:
-                result = utils.re_compile('^' + pat + '$').match(value)
+                result = utils.re_compile(r'^%s\Z' % (pat,)).match(value)
                 
             if result: # it's a match
                 return what, [x for x in result.groups()]


### PR DESCRIPTION
`$` allows a single line terminator before the end of the string, causing a KeyError when a route would otherwise match. This corrects the result to a “not found”.
#316 in a new branch.
