### PR TITLE
Don't set session cookie again and again on _save()

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -145,6 +145,14 @@ class Session(object):
         cookie_path = self._config.cookie_path
         httponly = self._config.httponly
         secure = self._config.secure
+
+        # Don't set session_id cookie again and again whenever _save() called
+        # This checks whether cookie header is already set or not,
+        # if yes just return set cookie otherwise
+        for h,v in web.ctx.headers:
+            cookie = web.parse_cookies(v)
+            if cookie.get(cookie_name, '') == session_id:
+                return
         web.setcookie(cookie_name, session_id, expires=expires, domain=cookie_domain, httponly=httponly, secure=secure, path=cookie_path)
     
     def _generate_session_id(self):


### PR DESCRIPTION
I encountered a situation where i call `session._save()` to save some data in session. This adds `session_id` in cookie header as many time as _save() called. This increases the response header size. Below is POC.  

```python
import web
from web.session import DiskStore, Session

urls = ('/test', 'Test')
app = web.application(urls, globals())

store = DiskStore("my_sessions")
session = Session(app, store)

web.config.debug = False

web.config.session_parameters['cookie_name'] = 'my_session'
web.config.session_parameters['cookie_domain'] = None
web.config.session_parameters['timeout'] = 86400, #24 * 60 * 60, # 24 hours   in seconds
web.config.session_parameters['ignore_expiry'] = True
web.config.session_parameters['ignore_change_ip'] = True
web.config.session_parameters['secret_key'] = 'fLjUfxqXtfNoIldA0A0J'
web.config.session_parameters['expired_message'] = 'Session expired'
web.ctx.session = session

def add_state():
	web.ctx.session = session

class Test(object):
	def GET(self):
		print "saving session using _save"
		web.ctx.session._save()
		web.ctx.session._save()
		web.ctx.session._save()
		print "headers: ", web.ctx.headers
		return "Hello!"

if __name__ == "__main__":
	app.add_processor(web.loadhook(add_state))
	app.run()
```

```
# HTTP Response header
HTTP/1.1 200 OK
Set-Cookie: webpy_session_id=d6713bc6af10abe286aa5bcffaf908d35c8b0c4e; Path=/; httponly
Set-Cookie: webpy_session_id=d6713bc6af10abe286aa5bcffaf908d35c8b0c4e; Path=/; httponly
Set-Cookie: webpy_session_id=d6713bc6af10abe286aa5bcffaf908d35c8b0c4e; Path=/; httponly
Set-Cookie: webpy_session_id=d6713bc6af10abe286aa5bcffaf908d35c8b0c4e; Path=/; httponly
Transfer-Encoding: chunked
Date: Thu, 21 May 2015 03:17:11 GMT
Server: localhost
```	