### PR TITLE
some db.py error fix

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -811,7 +811,7 @@ class DB:
             >>> db.supports_multiple_insert = True
             >>> values = [{"name": "foo", "email": "foo@example.com"}, {"name": "bar", "email": "bar@example.com"}]
             >>> db.multiple_insert('person', values=values, _test=True)
-            <sql: "INSERT INTO person (name, email) VALUES ('foo', 'foo@example.com'), ('bar', 'bar@example.com')">
+            <sql: "INSERT INTO person (email, name) VALUES ('foo@example.com', 'foo'), ('bar@example.com', 'bar')">
         """
         if not values:
             return []

--- a/web/db.py
+++ b/web/db.py
@@ -4,7 +4,7 @@ Database API
 """
 
 __all__ = [
-  "UnknownParamstyle", "UnknownDB", "TransactionError", 
+  "UnknownParamstyle", "UnknownDB", "TransactionError",
   "sqllist", "sqlors", "reparam", "sqlquote",
   "SQLQuery", "SQLParam", "sqlparam",
   "SQLLiteral", "sqlliteral",
@@ -20,7 +20,7 @@ except ImportError:
 try: set
 except NameError:
     from sets import Set as set
-    
+
 from utils import threadeddict, storage, iters, iterbetter, safestr, safeunicode
 
 try:
@@ -35,7 +35,7 @@ class UnknownDB(Exception):
     """raised for unsupported dbms"""
     pass
 
-class _ItplError(ValueError): 
+class _ItplError(ValueError):
     def __init__(self, text, pos):
         ValueError.__init__(self)
         self.text = text
@@ -46,18 +46,18 @@ class _ItplError(ValueError):
 
 class TransactionError(Exception): pass
 
-class UnknownParamstyle(Exception): 
+class UnknownParamstyle(Exception):
     """
     raised for unsupported db paramstyles
 
     (currently supported: qmark, numeric, format, pyformat)
     """
     pass
-    
+
 class SQLParam(object):
     """
     Parameter in SQLQuery.
-    
+
         >>> q = SQLQuery(["SELECT * FROM test WHERE name=", SQLParam("joe")])
         >>> q
         <sql: "SELECT * FROM test WHERE name='joe'">
@@ -70,7 +70,7 @@ class SQLParam(object):
 
     def __init__(self, value):
         self.value = value
-        
+
     def get_marker(self, paramstyle='pyformat'):
         if paramstyle == 'qmark':
             return '?'
@@ -79,19 +79,19 @@ class SQLParam(object):
         elif paramstyle is None or paramstyle in ['format', 'pyformat']:
             return '%s'
         raise UnknownParamstyle, paramstyle
-        
-    def sqlquery(self): 
+
+    def sqlquery(self):
         return SQLQuery([self])
-        
+
     def __add__(self, other):
         return self.sqlquery() + other
-        
+
     def __radd__(self, other):
-        return other + self.sqlquery() 
-            
-    def __str__(self): 
+        return other + self.sqlquery()
+
+    def __str__(self):
         return str(self.value)
-    
+
     def __repr__(self):
         return '<param: %s>' % repr(self.value)
 
@@ -111,7 +111,7 @@ class SQLQuery(object):
     # tested in sqlquote's docstring
     def __init__(self, items=None):
         r"""Creates a new SQLQuery.
-        
+
             >>> SQLQuery("x")
             <sql: 'x'>
             >>> q = SQLQuery(['SELECT * FROM ', 'test', ' WHERE x=', SQLParam(1)])
@@ -132,7 +132,7 @@ class SQLQuery(object):
             self.items = list(items.items)
         else:
             self.items = [items]
-            
+
         # Take care of SQLLiterals
         for i, item in enumerate(self.items):
             if isinstance(item, SQLParam) and isinstance(item.value, SQLLiteral):
@@ -155,7 +155,7 @@ class SQLQuery(object):
             items = [other]
         else:
             return NotImplemented
-            
+
         return SQLQuery(items + self.items)
 
     def __iadd__(self, other):
@@ -169,7 +169,7 @@ class SQLQuery(object):
 
     def __len__(self):
         return len(self.query())
-        
+
     def query(self, paramstyle=None):
         """
         Returns the query part of the sql query.
@@ -193,7 +193,7 @@ class SQLQuery(object):
                         x = x.replace('%', '%%')
                 s.append(x)
         return "".join(s)
-    
+
     def values(self):
         """
         Returns the values of the parameters used in the sql query.
@@ -202,11 +202,11 @@ class SQLQuery(object):
             ['joe']
         """
         return [i.value for i in self.items if isinstance(i, SQLParam)]
-        
+
     def join(items, sep=' ', prefix=None, suffix=None, target=None):
         """
         Joins multiple queries.
-        
+
         >>> SQLQuery.join(['a', 'b'], ', ')
         <sql: 'a, b'>
 
@@ -236,25 +236,25 @@ class SQLQuery(object):
         if suffix:
             target_items.append(suffix)
         return target
-    
+
     join = staticmethod(join)
-    
+
     def _str(self):
         try:
-            return self.query() % tuple([sqlify(x) for x in self.values()])            
+            return self.query() % tuple([sqlify(x) for x in self.values()])
         except (ValueError, TypeError):
             return self.query()
-        
+
     def __str__(self):
         return safestr(self._str())
-        
+
     def __unicode__(self):
         return safeunicode(self._str())
 
     def __repr__(self):
         return '<sql: %s>' % repr(str(self))
 
-class SQLLiteral: 
+class SQLLiteral:
     """
     Protects a string from `sqlquote`.
 
@@ -263,10 +263,10 @@ class SQLLiteral:
         >>> sqlquote(SQLLiteral('NOW()'))
         <sql: 'NOW()'>
     """
-    def __init__(self, v): 
+    def __init__(self, v):
         self.v = v
 
-    def __repr__(self): 
+    def __repr__(self):
         return self.v
 
 sqlliteral = SQLLiteral
@@ -285,7 +285,7 @@ def _sqllist(values):
     items.append(')')
     return SQLQuery(items)
 
-def reparam(string_, dictionary): 
+def reparam(string_, dictionary):
     """
     Takes a string and a dictionary and interpolates the string
     using values from the dictionary. Returns an `SQLQuery` for the result.
@@ -304,11 +304,11 @@ def reparam(string_, dictionary):
         if live:
             v = eval(chunk, dictionary)
             result.append(sqlquote(v))
-        else: 
+        else:
             result.append(chunk)
     return SQLQuery.join(result, '')
 
-def sqlify(obj): 
+def sqlify(obj):
     """
     converts `obj` to its proper SQL version
 
@@ -336,10 +336,10 @@ def sqlify(obj):
         if isinstance(obj, unicode): obj = obj.encode('utf8')
         return repr(obj)
 
-def sqllist(lst): 
+def sqllist(lst):
     """
     Converts the arguments for use in something like a WHERE clause.
-    
+
         >>> sqllist(['a', 'b'])
         'a, b'
         >>> sqllist('a')
@@ -347,14 +347,14 @@ def sqllist(lst):
         >>> sqllist(u'abc')
         u'abc'
     """
-    if isinstance(lst, basestring): 
+    if isinstance(lst, basestring):
         return lst
     else:
         return ', '.join(lst)
 
 def sqlors(left, lst):
     """
-    `left is a SQL clause like `tablename.arg = ` 
+    `left is a SQL clause like `tablename.arg = `
     and `lst` is a list of values. Returns a reparam-style
     pair featuring the SQL that ORs together the clause
     for each item in the lst.
@@ -377,17 +377,17 @@ def sqlors(left, lst):
             lst = lst[0]
 
     if isinstance(lst, iters):
-        return SQLQuery(['('] + 
+        return SQLQuery(['('] +
           sum([[left, sqlparam(x), ' OR '] for x in lst], []) +
           ['1=2)']
         )
     else:
         return left + sqlparam(lst)
-        
-def sqlwhere(dictionary, grouping=' AND '): 
+
+def sqlwhere(dictionary, grouping=' AND '):
     """
     Converts a `dictionary` to an SQL WHERE clause `SQLQuery`.
-    
+
         >>> sqlwhere({'cust_id': 2, 'order_id':3})
         <sql: 'order_id = 3 AND cust_id = 2'>
         >>> sqlwhere({'cust_id': 2, 'order_id':3}, grouping=', ')
@@ -397,7 +397,7 @@ def sqlwhere(dictionary, grouping=' AND '):
     """
     return SQLQuery.join([k + ' = ' + sqlparam(v) for k, v in dictionary.items()], grouping)
 
-def sqlquote(a): 
+def sqlquote(a):
     """
     Ensures `a` is quoted properly for use in a SQL query.
 
@@ -444,7 +444,7 @@ class Transaction:
                 self.query('ROLLBACK TO SAVEPOINT webpy_sp_%s')
 
         class dummy_engine:
-            """Transaction Engine used instead of subtransaction_engine 
+            """Transaction Engine used instead of subtransaction_engine
             when sub transactions are not supported."""
             do_transact = do_commit = do_rollback = lambda self: None
 
@@ -479,7 +479,7 @@ class Transaction:
             self.engine.do_rollback()
             self.ctx.transactions = self.ctx.transactions[:self.transaction_count]
 
-class DB: 
+class DB:
     """Database"""
     def __init__(self, db_module, keywords):
         """Creates a database.
@@ -495,77 +495,77 @@ class DB:
         # flag to enable/disable printing queries
         self.printing = config.get('debug_sql', config.get('debug', False))
         self.supports_multiple_insert = False
-        
+
         try:
             import DBUtils
             # enable pooling if DBUtils module is available.
             self.has_pooling = True
         except ImportError:
             self.has_pooling = False
-            
+
         # Pooling can be disabled by passing pooling=False in the keywords.
         self.has_pooling = self.keywords.pop('pooling', True) and self.has_pooling
-            
-    def _getctx(self): 
+
+    def _getctx(self):
         if not self._ctx.get('db'):
             self._load_context(self._ctx)
         return self._ctx
     ctx = property(_getctx)
-    
+
     def _load_context(self, ctx):
         ctx.dbq_count = 0
         ctx.transactions = [] # stack of transactions
-        
+
         if self.has_pooling:
             ctx.db = self._connect_with_pooling(self.keywords)
         else:
             ctx.db = self._connect(self.keywords)
         ctx.db_execute = self._db_execute
-        
+
         if not hasattr(ctx.db, 'commit'):
             ctx.db.commit = lambda: None
 
         if not hasattr(ctx.db, 'rollback'):
             ctx.db.rollback = lambda: None
-            
+
         def commit(unload=True):
-            # do db commit and release the connection if pooling is enabled.            
+            # do db commit and release the connection if pooling is enabled.
             ctx.db.commit()
             if unload and self.has_pooling:
                 self._unload_context(self._ctx)
-                
+
         def rollback():
             # do db rollback and release the connection if pooling is enabled.
             ctx.db.rollback()
             if self.has_pooling:
                 self._unload_context(self._ctx)
-                
+
         ctx.commit = commit
         ctx.rollback = rollback
-            
+
     def _unload_context(self, ctx):
         del ctx.db
-            
+
     def _connect(self, keywords):
         return self.db_module.connect(**keywords)
-        
+
     def _connect_with_pooling(self, keywords):
         def get_pooled_db():
             from DBUtils import PooledDB
 
             # In DBUtils 0.9.3, `dbapi` argument is renamed as `creator`
             # see Bug#122112
-            
+
             if PooledDB.__version__.split('.') < '0.9.3'.split('.'):
                 return PooledDB.PooledDB(dbapi=self.db_module, **keywords)
             else:
                 return PooledDB.PooledDB(creator=self.db_module, **keywords)
-        
+
         if getattr(self, '_pooleddb', None) is None:
             self._pooleddb = get_pooled_db()
-        
+
         return self._pooleddb.connection()
-        
+
     def _db_cursor(self):
         return self.ctx.db.cursor()
 
@@ -581,10 +581,10 @@ class DB:
             return '%s'
         raise UnknownParamstyle, style
 
-    def _db_execute(self, cur, sql_query): 
+    def _db_execute(self, cur, sql_query):
         """executes an sql query"""
         self.ctx.dbq_count += 1
-        
+
         try:
             a = time.time()
             query, params = self._process_query(sql_query)
@@ -610,8 +610,8 @@ class DB:
         query = sql_query.query(paramstyle)
         params = sql_query.values()
         return query, params
-    
-    def _where(self, where, vars): 
+
+    def _where(self, where, vars):
         if isinstance(where, (int, long)):
             where = "id = " + sqlparam(where)
         #@@@ for backward-compatibility
@@ -622,7 +622,7 @@ class DB:
         elif isinstance(where, SQLQuery):
             pass
         else:
-            where = reparam(where, vars)        
+            where = reparam(where, vars)
         return where
 
     def _where_dict(self, where):
@@ -633,13 +633,13 @@ class DB:
             return SQLQuery.join(where_clauses, " AND ")
         else:
             return None
-    
-    def query(self, sql_query, vars=None, processed=False, _test=False): 
+
+    def query(self, sql_query, vars=None, processed=False, _test=False):
         """
         Execute SQL query `sql_query` using dictionary `vars` to interpolate it.
-        If `processed=True`, `vars` is a `reparam`-style list to use 
+        If `processed=True`, `vars` is a `reparam`-style list to use
         instead of interpolating.
-        
+
             >>> db = DB(None, {})
             >>> db.query("SELECT * FROM foo", _test=True)
             <sql: 'SELECT * FROM foo'>
@@ -649,15 +649,15 @@ class DB:
             <sql: "SELECT * FROM foo WHERE x = 'f'">
         """
         if vars is None: vars = {}
-        
+
         if not processed and not isinstance(sql_query, SQLQuery):
             sql_query = reparam(sql_query, vars)
-        
+
         if _test: return sql_query
-        
+
         db_cursor = self._db_cursor()
         self._db_execute(db_cursor, sql_query)
-        
+
         if db_cursor.description:
             names = [x[0] for x in db_cursor.description]
             def iterwrapper():
@@ -671,18 +671,18 @@ class DB:
                                for x in db_cursor.fetchall()]
         else:
             out = db_cursor.rowcount
-        
-        if not self.ctx.transactions: 
+
+        if not self.ctx.transactions:
             self.ctx.commit()
         return out
-    
-    def select(self, tables, vars=None, what='*', where=None, order=None, group=None, 
-               limit=None, offset=None, _test=False): 
+
+    def select(self, tables, vars=None, what='*', where=None, order=None, group=None,
+               limit=None, offset=None, _test=False):
         """
-        Selects `what` from `tables` with clauses `where`, `order`, 
-        `group`, `limit`, and `offset`. Uses vars to interpolate. 
+        Selects `what` from `tables` with clauses `where`, `order`,
+        `group`, `limit`, and `offset`. Uses vars to interpolate.
         Otherwise, each clause can be a SQLQuery.
-        
+
             >>> db = DB(None, {})
             >>> db.select('foo', _test=True)
             <sql: 'SELECT * FROM foo'>
@@ -697,12 +697,12 @@ class DB:
         qout = SQLQuery.join(clauses)
         if _test: return qout
         return self.query(qout, processed=True)
-    
-    def where(self, table, what='*', order=None, group=None, limit=None, 
+
+    def where(self, table, what='*', order=None, group=None, limit=None,
               offset=None, _test=False, **kwargs):
         """
         Selects from `table` where keys are equal to values in `kwargs`.
-        
+
             >>> db = DB(None, {})
             >>> db.where('foo', bar_id=3, _test=True)
             <sql: 'SELECT * FROM foo WHERE bar_id = 3'>
@@ -711,12 +711,12 @@ class DB:
             >>> db.where('foo', _test=True)
             <sql: 'SELECT * FROM foo'>
         """
-        where = self._where_dict(kwargs)            
-        return self.select(table, what=what, order=order, 
-               group=group, limit=limit, offset=offset, _test=_test, 
+        where = self._where_dict(kwargs)
+        return self.select(table, what=what, order=order,
+               group=group, limit=limit, offset=offset, _test=_test,
                where=where)
-    
-    def sql_clauses(self, what, tables, where, group, order, limit, offset): 
+
+    def sql_clauses(self, what, tables, where, group, order, limit, offset):
         return (
             ('SELECT', what),
             ('FROM', sqllist(tables)),
@@ -725,8 +725,8 @@ class DB:
             ('ORDER BY', order),
             ('LIMIT', limit),
             ('OFFSET', offset))
-    
-    def gen_clause(self, sql, val, vars): 
+
+    def gen_clause(self, sql, val, vars):
         if isinstance(val, (int, long)):
             if sql == 'WHERE':
                 nout = 'id = ' + sqlquote(val)
@@ -748,12 +748,12 @@ class DB:
 
         return xjoin(sql, nout)
 
-    def insert(self, tablename, seqname=None, _test=False, **values): 
+    def insert(self, tablename, seqname=None, _test=False, **values):
         """
         Inserts `values` into `tablename`. Returns current sequence ID.
         Set `seqname` to the ID if it's not the default, or to `False`
         if there isn't one.
-        
+
             >>> db = DB(None, {})
             >>> q = db.insert('foo', name='bob', age=2, created=SQLLiteral('NOW()'), _test=True)
             >>> q
@@ -764,7 +764,7 @@ class DB:
             [2, 'bob']
         """
         def q(x): return "(" + x + ")"
-        
+
         if values:
             _keys = SQLQuery.join(values.keys(), ', ')
             _values = SQLQuery.join([sqlparam(v) for v in values.values()], ', ')
@@ -773,13 +773,13 @@ class DB:
             sql_query = SQLQuery(self._get_insert_default_values_query(tablename))
 
         if _test: return sql_query
-        
+
         db_cursor = self._db_cursor()
-        if seqname is not False: 
+        if seqname is not False:
             sql_query = self._process_insert_query(sql_query, tablename, seqname)
 
         if isinstance(sql_query, tuple):
-            # for some databases, a separate query has to be made to find 
+            # for some databases, a separate query has to be made to find
             # the id of the inserted row.
             q1, q2 = sql_query
             self._db_execute(db_cursor, q1)
@@ -787,42 +787,42 @@ class DB:
         else:
             self._db_execute(db_cursor, sql_query)
 
-        try: 
+        try:
             out = db_cursor.fetchone()[0]
-        except Exception: 
+        except Exception:
             out = None
-        
-        if not self.ctx.transactions: 
+
+        if not self.ctx.transactions:
             self.ctx.commit()
         return out
-        
+
     def _get_insert_default_values_query(self, table):
         return "INSERT INTO %s DEFAULT VALUES" % table
 
     def multiple_insert(self, tablename, values, seqname=None, _test=False):
         """
-        Inserts multiple rows into `tablename`. The `values` must be a list of dictioanries, 
+        Inserts multiple rows into `tablename`. The `values` must be a list of dictioanries,
         one for each row to be inserted, each with the same set of keys.
-        Returns the list of ids of the inserted rows.        
+        Returns the list of ids of the inserted rows.
         Set `seqname` to the ID if it's not the default, or to `False`
         if there isn't one.
-        
+
             >>> db = DB(None, {})
             >>> db.supports_multiple_insert = True
             >>> values = [{"name": "foo", "email": "foo@example.com"}, {"name": "bar", "email": "bar@example.com"}]
             >>> db.multiple_insert('person', values=values, _test=True)
             <sql: "INSERT INTO person (name, email) VALUES ('foo', 'foo@example.com'), ('bar', 'bar@example.com')">
-        """        
+        """
         if not values:
             return []
-            
+
         if not self.supports_multiple_insert:
             out = [self.insert(tablename, seqname=seqname, _test=_test, **v) for v in values]
             if seqname is False:
                 return None
             else:
                 return out
-                
+
         keys = sorted(values[0].keys())
         #@@ make sure all keys are valid
 
@@ -837,15 +837,15 @@ class DB:
             if i != 0:
                 sql_query.append(", ")
             SQLQuery.join([SQLParam(row[k]) for k in keys], sep=", ", target=sql_query, prefix="(", suffix=")")
-        
+
         if _test: return sql_query
 
         db_cursor = self._db_cursor()
-        if seqname is not False: 
+        if seqname is not False:
             sql_query = self._process_insert_query(sql_query, tablename, seqname)
 
         if isinstance(sql_query, tuple):
-            # for some databases, a separate query has to be made to find 
+            # for some databases, a separate query has to be made to find
             # the id of the inserted row.
             q1, q2 = sql_query
             self._db_execute(db_cursor, q1)
@@ -853,18 +853,18 @@ class DB:
         else:
             self._db_execute(db_cursor, sql_query)
 
-        try: 
+        try:
             out = db_cursor.fetchone()[0]
-            out = range(out-len(values)+1, out+1)        
-        except Exception: 
+            out = range(out-len(values)+1, out+1)
+        except Exception:
             out = None
 
-        if not self.ctx.transactions: 
+        if not self.ctx.transactions:
             self.ctx.commit()
         return out
 
-    
-    def update(self, tables, where, vars=None, _test=False, **values): 
+
+    def update(self, tables, where, vars=None, _test=False, **values):
         """
         Update `tables` with clause `where` (interpolated using `vars`)
         and setting `values`.
@@ -884,19 +884,19 @@ class DB:
         where = self._where(where, vars)
 
         query = (
-          "UPDATE " + sqllist(tables) + 
-          " SET " + sqlwhere(values, ', ') + 
+          "UPDATE " + sqllist(tables) +
+          " SET " + sqlwhere(values, ', ') +
           " WHERE " + where)
 
         if _test: return query
-        
+
         db_cursor = self._db_cursor()
         self._db_execute(db_cursor, query)
-        if not self.ctx.transactions: 
+        if not self.ctx.transactions:
             self.ctx.commit()
         return db_cursor.rowcount
-    
-    def delete(self, table, where, using=None, vars=None, _test=False): 
+
+    def delete(self, table, where, using=None, vars=None, _test=False):
         """
         Deletes from `table` with clauses `where` and `using`.
 
@@ -916,23 +916,23 @@ class DB:
 
         db_cursor = self._db_cursor()
         self._db_execute(db_cursor, q)
-        if not self.ctx.transactions: 
+        if not self.ctx.transactions:
             self.ctx.commit()
         return db_cursor.rowcount
 
     def _process_insert_query(self, query, tablename, seqname):
         return query
 
-    def transaction(self): 
+    def transaction(self):
         """Start a transaction."""
         return Transaction(self.ctx)
-    
-class PostgresDB(DB): 
+
+class PostgresDB(DB):
     """Postgres driver."""
     def __init__(self, **keywords):
         if 'pw' in keywords:
             keywords['password'] = keywords.pop('pw')
-            
+
         db_module = import_driver(["psycopg2", "psycopg", "pgdb"], preferred=keywords.pop('driver', None))
         if db_module.__name__ == "psycopg2":
             import psycopg2.extensions
@@ -943,25 +943,27 @@ class PostgresDB(DB):
         # if db is not provided postgres driver will take it from PGDATABASE environment variable
         if 'db' in keywords:
             keywords['database'] = keywords.pop('db')
-        
+
         self.dbname = "postgres"
         self.paramstyle = db_module.paramstyle
         DB.__init__(self, db_module, keywords)
         self.supports_multiple_insert = True
         self._sequences = None
-        
+
     def _process_insert_query(self, query, tablename, seqname):
-        if seqname is None:
-            # when seqname is not provided guess the seqname and make sure it exists
-            seqname = tablename + "_id_seq"
-            if seqname not in self._get_all_sequences():
-                seqname = None
-        
+
+        # modify by bigzhu: when seqname is not provided, no need guess. if you set 'id' key in pg94 will cause psycopg2.OperationalError: currval of sequence "xxx" is not yet defined in this session
+        #if seqname is None:
+        #    # when seqname is not provided guess the seqname and make sure it exists
+        #    seqname = tablename + "_id_seq"
+        #    if seqname not in self._get_all_sequences():
+        #        seqname = None
+
         if seqname:
             query += "; SELECT currval('%s')" % seqname
-            
+
         return query
-    
+
     def _get_all_sequences(self):
         """Query postgres to find names of all sequences used in this database."""
         if self._sequences is None:
@@ -977,13 +979,13 @@ class PostgresDB(DB):
             # fallback for pgdb driver
             conn.cursor().execute("set client_encoding to 'UTF-8'")
         return conn
-        
+
     def _connect_with_pooling(self, keywords):
         conn = DB._connect_with_pooling(self, keywords)
         conn._con._con.set_client_encoding('UTF8')
         return conn
 
-class MySQLDB(DB): 
+class MySQLDB(DB):
     def __init__(self, **keywords):
         import MySQLdb as db
         if 'pw' in keywords:
@@ -999,10 +1001,10 @@ class MySQLDB(DB):
         self.dbname = "mysql"
         DB.__init__(self, db, keywords)
         self.supports_multiple_insert = True
-        
+
     def _process_insert_query(self, query, tablename, seqname):
         return query, SQLQuery('SELECT last_insert_id();')
-        
+
     def _get_insert_default_values_query(self, table):
         return "INSERT INTO %s () VALUES()" % table
 
@@ -1019,13 +1021,13 @@ def import_driver(drivers, preferred=None):
             pass
     raise ImportError("Unable to import " + " or ".join(drivers))
 
-class SqliteDB(DB): 
+class SqliteDB(DB):
     def __init__(self, **keywords):
         db = import_driver(["sqlite3", "pysqlite2.dbapi2", "sqlite"], preferred=keywords.pop('driver', None))
 
         if db.__name__ in ["sqlite3", "pysqlite2.dbapi2"]:
             db.paramstyle = 'qmark'
-            
+
         # sqlite driver doesn't create datatime objects for timestamp columns unless `detect_types` option is passed.
         # It seems to be supported in sqlite3 and pysqlite2 drivers, not surte about sqlite.
         keywords.setdefault('detect_types', db.PARSE_DECLTYPES)
@@ -1033,12 +1035,12 @@ class SqliteDB(DB):
         self.paramstyle = db.paramstyle
         keywords['database'] = keywords.pop('db')
         keywords['pooling'] = False # sqlite don't allows connections to be shared by threads
-        self.dbname = "sqlite"        
+        self.dbname = "sqlite"
         DB.__init__(self, db, keywords)
 
     def _process_insert_query(self, query, tablename, seqname):
         return query, SQLQuery('SELECT last_insert_rowid();')
-    
+
     def query(self, *a, **kw):
         out = DB.query(self, *a, **kw)
         if isinstance(out, iterbetter):
@@ -1061,7 +1063,7 @@ class FirebirdDB(DB):
         self.paramstyle = db.paramstyle
 
         DB.__init__(self, db, keywords)
-        
+
     def delete(self, table, where=None, using=None, vars=None, _test=False):
         # firebird doesn't support using clause
         using=None
@@ -1081,7 +1083,7 @@ class FirebirdDB(DB):
 
 class MSSQLDB(DB):
     def __init__(self, **keywords):
-        import pymssql as db    
+        import pymssql as db
         if 'pw' in keywords:
             keywords['password'] = keywords.pop('pw')
         keywords['database'] = keywords.pop('db')
@@ -1091,14 +1093,14 @@ class MSSQLDB(DB):
     def _process_query(self, sql_query):
         """Takes the SQLQuery object and returns query string and parameters.
         """
-        # MSSQLDB expects params to be a tuple. 
+        # MSSQLDB expects params to be a tuple.
         # Overwriting the default implementation to convert params to tuple.
         paramstyle = getattr(self, 'paramstyle', 'pyformat')
         query = sql_query.query(paramstyle)
         params = sql_query.values()
         return query, tuple(params)
 
-    def sql_clauses(self, what, tables, where, group, order, limit, offset): 
+    def sql_clauses(self, what, tables, where, group, order, limit, offset):
         return (
             ('SELECT', what),
             ('TOP', limit),
@@ -1107,14 +1109,14 @@ class MSSQLDB(DB):
             ('GROUP BY', group),
             ('ORDER BY', order),
             ('OFFSET', offset))
-            
+
     def _test(self):
         """Test LIMIT.
 
             Fake presence of pymssql module for running tests.
             >>> import sys
             >>> sys.modules['pymssql'] = sys.modules['sys']
-            
+
             MSSQL has TOP clause instead of LIMIT clause.
             >>> db = MSSQLDB(db='test', user='joe', pw='secret')
             >>> db.select('foo', limit=4, _test=True)
@@ -1122,33 +1124,33 @@ class MSSQLDB(DB):
         """
         pass
 
-class OracleDB(DB): 
-    def __init__(self, **keywords): 
-        import cx_Oracle as db 
-        if 'pw' in keywords: 
-            keywords['password'] = keywords.pop('pw') 
+class OracleDB(DB):
+    def __init__(self, **keywords):
+        import cx_Oracle as db
+        if 'pw' in keywords:
+            keywords['password'] = keywords.pop('pw')
 
-        #@@ TODO: use db.makedsn if host, port is specified 
-        keywords['dsn'] = keywords.pop('db') 
-        self.dbname = 'oracle' 
-        db.paramstyle = 'numeric' 
+        #@@ TODO: use db.makedsn if host, port is specified
+        keywords['dsn'] = keywords.pop('db')
+        self.dbname = 'oracle'
+        db.paramstyle = 'numeric'
         self.paramstyle = db.paramstyle
 
-        # oracle doesn't support pooling 
-        keywords.pop('pooling', None) 
-        DB.__init__(self, db, keywords) 
+        # oracle doesn't support pooling
+        keywords.pop('pooling', None)
+        DB.__init__(self, db, keywords)
 
-    def _process_insert_query(self, query, tablename, seqname): 
-        if seqname is None: 
+    def _process_insert_query(self, query, tablename, seqname):
+        if seqname is None:
             # It is not possible to get seq name from table name in Oracle
             return query
         else:
-            return query + "; SELECT %s.currval FROM dual" % seqname 
+            return query + "; SELECT %s.currval FROM dual" % seqname
 
 def dburl2dict(url):
     """
     Takes a URL to a database and parses it into an equivalent dictionary.
-    
+
         >>> dburl2dict('postgres://james:day@serverfarm.example.net:5432/mygreatdb')
         {'pw': 'day', 'dbn': 'postgres', 'db': 'mygreatdb', 'host': 'serverfarm.example.net', 'user': 'james', 'port': '5432'}
         >>> dburl2dict('postgres://james:day@serverfarm.example.net/mygreatdb')
@@ -1166,7 +1168,7 @@ def dburl2dict(url):
         host, rest = rest.split('/', 1)
         port = None
     db = rest
-    
+
     uq = urllib.unquote
     out = dict(dbn=dbn, user=uq(user), pw=uq(pw), host=uq(host), db=uq(db))
     if port: out['port'] = port
@@ -1175,8 +1177,8 @@ def dburl2dict(url):
 _databases = {}
 def database(dburl=None, **params):
     """Creates appropriate database using params.
-    
-    Pooling will be enabled if DBUtils module is available. 
+
+    Pooling will be enabled if DBUtils module is available.
     Pooling can be disabled by passing pooling=False in params.
     """
     if not dburl and not params:
@@ -1193,12 +1195,12 @@ def register_database(name, clazz):
     """
     Register a database.
 
-        >>> class LegacyDB(DB): 
-        ...     def __init__(self, **params): 
-        ...        pass 
+        >>> class LegacyDB(DB):
+        ...     def __init__(self, **params):
+        ...        pass
         ...
         >>> register_database('legacy', LegacyDB)
-        >>> db = database(dbn='legacy', db='test', user='joe', passwd='secret') 
+        >>> db = database(dbn='legacy', db='test', user='joe', passwd='secret')
     """
     _databases[name] = clazz
 
@@ -1209,7 +1211,7 @@ register_database('firebird', FirebirdDB)
 register_database('mssql', MSSQLDB)
 register_database('oracle', OracleDB)
 
-def _interpolate(format): 
+def _interpolate(format):
     """
     Takes a format string and returns a list of 2-tuples of the form
     (boolean, string) where boolean says whether string should be evaled
@@ -1232,7 +1234,7 @@ def _interpolate(format):
 
     while 1:
         dollar = format.find("$", pos)
-        if dollar < 0: 
+        if dollar < 0:
             break
         nextchar = format[dollar + 1]
 
@@ -1243,9 +1245,9 @@ def _interpolate(format):
                 match, pos = matchorfail(format, pos)
                 tstart, tend = match.regs[3]
                 token = format[tstart:tend]
-                if token == "{": 
+                if token == "{":
                     level = level + 1
-                elif token == "}":  
+                elif token == "}":
                     level = level - 1
             chunks.append((1, format[dollar + 2:pos - 1]))
 
@@ -1262,18 +1264,18 @@ def _interpolate(format):
                         match, pos = matchorfail(format, pos)
                         tstart, tend = match.regs[3]
                         token = format[tstart:tend]
-                        if token[0] in "([": 
+                        if token[0] in "([":
                             level = level + 1
-                        elif token[0] in ")]":  
+                        elif token[0] in ")]":
                             level = level - 1
-                else: 
+                else:
                     break
             chunks.append((1, format[dollar + 1:pos]))
         else:
             chunks.append((0, format[pos:dollar + 1]))
             pos = dollar + 1 + (nextchar == "$")
 
-    if pos < len(format): 
+    if pos < len(format):
         chunks.append((0, format[pos:]))
     return chunks
 

--- a/web/db.py
+++ b/web/db.py
@@ -823,11 +823,12 @@ class DB:
             else:
                 return out
                 
-        keys = values[0].keys()
+        keys = sorted(values[0].keys())
         #@@ make sure all keys are valid
 
         for v in values:
-            if v.keys() != keys:
+		    # make sure keys are sorted, keep compare correct
+            if sorted(v.keys()) != keys:
                 raise ValueError, 'Not all rows have the same keys'
 
         sql_query = SQLQuery('INSERT INTO %s (%s) VALUES ' % (tablename, ', '.join(keys)))


### PR DESCRIPTION
1. make sure keys are sorted, keep compare correct in multiple_insert
2. when seqname is not provided guess the seqname will cause error: 
   
   > psycopg2.OperationalError: currval of sequence "xxx" is not yet defined in this session
   
   when you insert id key in postgresql 9.4
   I'm disable the seqname guess, if you need insert return id, must provide seqname. It may cause some problems if you use seqname guess return insert id.
