### PR TITLE
Added unicode support for binding to unix domain sockets

### DIFF
--- a/web/wsgiserver/__init__.py
+++ b/web/wsgiserver/__init__.py
@@ -1775,7 +1775,7 @@ class HTTPServer(object):
         self.socket = socket.socket(family, type, proto)
         prevent_socket_inheritance(self.socket)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if self.nodelay and not isinstance(self.bind_addr, str):
+        if self.nodelay and not isinstance(self.bind_addr, basestring):
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         
         if self.ssl_adapter is not None:


### PR DESCRIPTION
If domain socket is provided as unicode, "No socket could be created" is raised
