### PR TITLE
template files without extension

### DIFF
--- a/web/template.py
+++ b/web/template.py
@@ -1001,7 +1001,7 @@ class Render:
             raise AttributeError, "No template named " + name            
 
     def _findfile(self, path_prefix): 
-        p = [f for f in glob.glob(path_prefix + '.*') if not f.endswith('~')] # skip backup files
+        p = [f for f in glob.glob(path_prefix + '*') if not f.endswith('~')] # skip backup files
         p.sort() # sort the matches for deterministic order
         return p and p[0]
             


### PR DESCRIPTION
If the template file names do not have an extension like 'file.html' but are named as 'file'
render = web.template.render('templates')
print render.hello('world')
[works only for files named as hello.(some extension)]
 The glob module used  requires unix style wildcards which are not the same as regex .
If it where regex then filename.* would match for filename as well filename.extension
This is not correct for wildcards . 

This could also be a design decision , If so please reply . 
