### PR TITLE
Template files without extension 

### DIFF
--- a/web/template.py
+++ b/web/template.py
@@ -1001,7 +1001,7 @@ class Render:
             raise AttributeError, "No template named " + name            
 
     def _findfile(self, path_prefix): 
-        p = [f for f in glob.glob(path_prefix + '*') if not f.endswith('~')] # skip backup files
+        p = [f for f in glob.glob(path_prefix + '*')+glob.glob(path_prefix) if not f.endswith('~')] # skip backup files
         p.sort() # sort the matches for deterministic order
         return p and p[0]
             

--- a/web/template.py
+++ b/web/template.py
@@ -1001,7 +1001,7 @@ class Render:
             raise AttributeError, "No template named " + name            
 
     def _findfile(self, path_prefix): 
-        p = [f for f in glob.glob(path_prefix + '.*') if not f.endswith('~')] # skip backup files
+        p = [f for f in glob.glob(path_prefix + '*') if not f.endswith('~')] # skip backup files
         p.sort() # sort the matches for deterministic order
         return p and p[0]
             


### PR DESCRIPTION
Adding filename.\* + filename to the fnpath search . This would include files with and without extensions
