### PR TITLE
Fixes #371 : webapp crashes when unicode text is returned as response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-#  - "3.1"
-#  - "3.2"
+  - "3.5"
 install: pip install -r test/requirements.txt --use-mirrors; if [ $TRAVIS_PYTHON_VERSION == 2* ] ; then pip install -r test/requirements2.txt --use-mirrors; fi
 script: python test/alltests.py
 before_install:

--- a/test/alltests.py
+++ b/test/alltests.py
@@ -1,7 +1,7 @@
 import webtest
 
 def suite():
-    modules = ["doctests", "db", "application", "session"]
+    modules = ["doctests", "db", "application", "session", "wsgi"]
     return webtest.suite(modules)
     
 if __name__ == "__main__":

--- a/test/application.py
+++ b/test/application.py
@@ -47,17 +47,17 @@ class ApplicationTest(webtest.TestCase):
         import foo
         app = foo.app
         
-        self.assertEquals(app.request('/').data, 'a')
+        self.assertEquals(app.request('/').data, b'a')
         
         # test class change
         time.sleep(1)
         write('foo.py', data % dict(classname='a', output='b'))
-        self.assertEquals(app.request('/').data, 'b')
+        self.assertEquals(app.request('/').data, b'b')
 
         # test urls change
         time.sleep(1)
         write('foo.py', data % dict(classname='c', output='c'))
-        self.assertEquals(app.request('/').data, 'c')
+        self.assertEquals(app.request('/').data, b'c')
         
     def testUppercaseMethods(self):
         urls = ("/", "hello")
@@ -111,13 +111,13 @@ class ApplicationTest(webtest.TestCase):
                 return "hello " + path
         app = web.application(urls, locals())
         
-        self.assertEquals(app.request('/blog/foo').data, 'blog foo')
-        self.assertEquals(app.request('/foo').data, 'hello foo')
+        self.assertEquals(app.request('/blog/foo').data, b'blog foo')
+        self.assertEquals(app.request('/foo').data, b'hello foo')
         
         def processor(handler):
             return web.ctx.path + ":" + handler()
         app.add_processor(processor)
-        self.assertEquals(app.request('/blog/foo').data, '/blog/foo:blog foo')
+        self.assertEquals(app.request('/blog/foo').data, b'/blog/foo:blog foo')
     
     def test_subdomains(self):
         def create_app(name):
@@ -138,10 +138,10 @@ class ApplicationTest(webtest.TestCase):
             result = app.request('/', host=host)
             self.assertEquals(result.data, expected_result)
             
-        test('a.example.com', 'a')
-        test('b.example.com', 'b')
-        test('c.example.com', '*')
-        test('d.example.com', '*')
+        test('a.example.com', b'a')
+        test('b.example.com', b'b')
+        test('c.example.com', b'*')
+        test('d.example.com', b'*')
         
     def test_redirect(self):
         urls = (
@@ -223,23 +223,20 @@ class ApplicationTest(webtest.TestCase):
                     return i.file.value
                 else:
                     i = web.input()
-                    return repr(dict(i))
+                    return repr(dict(i)).replace('u','')
                 
         app = web.application(urls, locals())
         
         def f(name):
             path = '/?' + urlencode({"name": name.encode('utf-8')})
-            self.assertEquals(app.request(path).data, repr(name))
+            self.assertEquals(app.request(path).data.decode('utf-8'), repr(name))
             
         f(u'\u1234')
         f(u'foo')
 
         response = app.request('/', method='POST', data=dict(name='foo'))
 
-        if PY2:
-            self.assertEquals(response.data, "{'name': u'foo'}")
-        else:
-            self.assertEquals(response.data, "{'name': 'foo'}")
+        self.assertEquals(response.data, b"{'name': 'foo'}")
 
         
         data = '--boundary\r\nContent-Disposition: form-data; name="x"\r\n\r\nfoo\r\n--boundary\r\nContent-Disposition: form-data; name="file"; filename="a.txt"\r\nContent-Type: text/plain\r\n\r\na\r\n--boundary--\r\n'
@@ -247,10 +244,7 @@ class ApplicationTest(webtest.TestCase):
         response = app.request('/multipart', method="POST", data=data, headers=headers)
 
 
-        if PY2:
-            self.assertEquals(response.data, 'a')
-        else:
-            self.assertEquals(response.data, str(b'a'))
+        self.assertEquals(response.data, b'a')
 
         
     def testCustomNotFound(self):
@@ -273,19 +267,19 @@ class ApplicationTest(webtest.TestCase):
             self.assertEquals(response.status.split()[0], "404")
             self.assertEquals(response.data, message)
             
-        assert_notfound("/a/foo", "not found 1")
-        assert_notfound("/b/foo", "not found")
+        assert_notfound("/a/foo", b"not found 1")
+        assert_notfound("/b/foo", b"not found")
         
         app.notfound = lambda: web.HTTPError("404 Not Found", {}, "not found 2")
-        assert_notfound("/a/foo", "not found 1")
-        assert_notfound("/b/foo", "not found 2")
+        assert_notfound("/a/foo", b"not found 1")
+        assert_notfound("/b/foo", b"not found 2")
 
     def testIter(self):
-        self.assertEquals(app.request('/iter').data, 'hello, world')
-        self.assertEquals(app.request('/iter?name=web').data, 'hello, web')
+        self.assertEquals(app.request('/iter').data, b'hello, world')
+        self.assertEquals(app.request('/iter?name=web').data, b'hello, web')
 
-        self.assertEquals(app.request('/iter', method='POST').data, 'hello, world')
-        self.assertEquals(app.request('/iter', method='POST', data='name=web').data, 'hello, web')
+        self.assertEquals(app.request('/iter', method='POST').data, b'hello, world')
+        self.assertEquals(app.request('/iter', method='POST', data='name=web').data, b'hello, web')
 
     def testUnload(self):
         x = web.storage(a=0)
@@ -324,10 +318,10 @@ class ApplicationTest(webtest.TestCase):
         def f(path):
             return app.request(path).data
                 
-        self.assertEquals(f('/?x=2'), '/?x=1')
+        self.assertEquals(f('/?x=2'), b'/?x=1')
 
         p = f('/?y=1&y=2&x=2')
-        self.assertTrue(p == '/?y=1&y=2&x=1' or p == '/?x=1&y=1&y=2')
+        self.assertTrue(p == b'/?y=1&y=2&x=1' or p == b'/?x=1&y=1&y=2')
         
     def test_setcookie(self):
         urls = (

--- a/test/session.py
+++ b/test/session.py
@@ -36,11 +36,11 @@ class SessionTest(webtest.TestCase):
         
     def testSession(self):
         b = self.app.browser() 
-        self.assertEquals(b.open('/count').read(), '1')
-        self.assertEquals(b.open('/count').read(), '2')
-        self.assertEquals(b.open('/count').read(), '3')
+        self.assertEquals(b.open('/count').read(), b'1')
+        self.assertEquals(b.open('/count').read(), b'2')
+        self.assertEquals(b.open('/count').read(), b'3')
         b.open('/reset')
-        self.assertEquals(b.open('/count').read(), '1')
+        self.assertEquals(b.open('/count').read(), b'1')
 
     def testParallelSessions(self):
         b1 = self.app.browser()
@@ -49,23 +49,23 @@ class SessionTest(webtest.TestCase):
         b1.open('/count')
         
         for i in range(1, 10):
-            self.assertEquals(b1.open('/count').read(), str(i+1))
-            self.assertEquals(b2.open('/count').read(), str(i))
+            self.assertEquals(b1.open('/count').read(), str(i+1).encode('utf8'))
+            self.assertEquals(b2.open('/count').read(), str(i).encode('utf8'))
 
     def testBadSessionId(self):
         b = self.app.browser()
-        self.assertEquals(b.open('/count').read(), '1')
-        self.assertEquals(b.open('/count').read(), '2')
+        self.assertEquals(b.open('/count').read(), b'1')
+        self.assertEquals(b.open('/count').read(), b'2')
         
         cookie = b.cookiejar._cookies['0.0.0.0']['/']['webpy_session_id']
         cookie.value = '/etc/password'
-        self.assertEquals(b.open('/count').read(), '1')
+        self.assertEquals(b.open('/count').read(), b'1')
 
     def testRedirect(self):
         b = self.app.browser()
         b.open("/redirect")
         b.open("/session/request_token")
-        self.assertEquals(b.data, '123')
+        self.assertEquals(b.data, b'123')
 
 class DBSessionTest(SessionTest):
     """Session test with db store."""

--- a/test/wsgi.py
+++ b/test/wsgi.py
@@ -1,0 +1,52 @@
+import webtest, web
+import threading, time
+
+class WSGITest(webtest.TestCase):
+    def test_layers_unicode(self):
+        urls = (
+            '/', 'uni',
+        )
+
+        class uni:
+            def GET(self):
+                return u"\u0C05\u0C06"
+
+        app = web.application(urls, locals())
+
+        thread = threading.Thread(target=app.run)
+        thread.start()
+        time.sleep(0.5)
+
+        b = web.browser.Browser()
+        r = b.open('/').read()
+        s = r.decode('utf8')
+        self.assertEqual(s, u"\u0C05\u0C06")
+
+        app.stop()
+        thread.join()
+
+
+    def test_layers_bytes(self):
+        urls = (
+            '/', 'bytes',
+        )
+
+        class bytes:
+            def GET(self):
+                return b'abcdef'
+
+        app = web.application(urls, locals())
+
+        thread = threading.Thread(target=app.run)
+        thread.start()
+        time.sleep(0.5)
+
+        b = web.browser.Browser()
+        r = b.open('/')
+        self.assertEqual(r.read(), b'abcdef')
+
+        app.stop()
+        thread.join()
+
+if __name__ == '__main__':
+    webtest.main()

--- a/web/browser.py
+++ b/web/browser.py
@@ -3,6 +3,7 @@
 """
 from .utils import re_compile
 from .net import htmlunquote
+from io import BytesIO, StringIO
 
 import copy
 
@@ -22,7 +23,6 @@ else:
     get_type = lambda x: x.type
 
 try: #Py3
-    from io import StringIO
     from http.client import HTTPMessage
     from urllib.request import HTTPHandler, HTTPCookieProcessor, build_opener, Request, HTTPError
     from urllib.request import build_opener as urllib_build_opener
@@ -30,7 +30,6 @@ try: #Py3
     from http.cookiejar import CookieJar
     from urllib.response import addinfourl
 except ImportError:  #Py2
-    from StringIO import StringIO
     from httplib import HTTPMessage
     from urllib import addinfourl
     from urllib2 import HTTPHandler, HTTPCookieProcessor, Request, HTTPError
@@ -112,7 +111,7 @@ class Browser:
 
     def get_response(self):
         """Returns a copy of the current response."""
-        return addinfourl(StringIO(self.data), self._response.info(), self._response.geturl())
+        return addinfourl(BytesIO(self.data), self._response.info(), self._response.geturl())
 
     def get_soup(self):
         """Returns beautiful soup of the current document."""
@@ -264,12 +263,12 @@ class AppHandler(HTTPHandler):
         data = "\r\n".join(["%s: %s" % (k, v) for k, v in result.header_items])
 
         if PY2:
-            headers = HTTPMessage(StringIO(data))
+            headers = HTTPMessage(BytesIO(data))
         else:
             import email
             headers = email.message_from_string(data)
 
-        response = addinfourl(StringIO(result.data), headers, url)
+        response = addinfourl(BytesIO(result.data), headers, url)
         code, msg = result.status.split(None, 1)
         response.code, response.msg = int(code), msg
         return response

--- a/web/form.py
+++ b/web/form.py
@@ -14,7 +14,9 @@ def attrget(obj, attr, value=None):
         # Handle the case where has_key takes different number of arguments.
         # This is the case with Model objects on appengine. See #134
         pass
-    if hasattr(obj, attr):
+    if hasattr(obj, 'keys') and attr in obj.keys(): #needed for Py3, has_key doesn't exist anymore
+        return obj[attr]
+    elif hasattr(obj, attr):
         return getattr(obj, attr)
     return value
 
@@ -25,6 +27,10 @@ class Form(object):
         >>> f = Form(Textbox("x"))
         >>> f.render()
         u'<table>\n    <tr><th><label for="x">x</label></th><td><input id="x" name="x" type="text"/></td></tr>\n</table>'
+        >>> f.fill(x="42")
+        True
+        >>> f.render()
+        u'<table>\n    <tr><th><label for="x">x</label></th><td><input id="x" name="x" type="text" value="42"/></td></tr>\n</table>'
     """
     def __init__(self, *inputs, **kw):
         self.inputs = inputs

--- a/web/httpserver.py
+++ b/web/httpserver.py
@@ -23,9 +23,9 @@ except ImportError:
     from urllib import unquote
 
 try:
-    from io import StringIO
+    from io import BytesIO
 except ImportError:
-    from StringIO import StringIO
+    from StringIO import BytesIO
 
 __all__ = ["runsimple"]
 
@@ -230,7 +230,8 @@ class StaticApp(SimpleHTTPRequestHandler):
         self.start_response = start_response
 
     def send_response(self, status, msg=""):
-        self.status = str(status) + " " + msg
+        #the int(status) call is needed because in Py3 status is an enum.IntEnum and we need the integer behind
+        self.status = str(int(status)) + " " + msg
 
     def send_header(self, name, value):
         self.headers.append((name, value))
@@ -248,7 +249,7 @@ class StaticApp(SimpleHTTPRequestHandler):
                               environ.get('REMOTE_PORT','-')
         self.command = environ.get('REQUEST_METHOD', '-')
 
-        self.wfile = StringIO() # for capturing error
+        self.wfile = BytesIO() # for capturing error
 
         try:
             path = self.translate_path(self.path)
@@ -305,7 +306,7 @@ class LogMiddleware:
         self.app = app
         self.format = '%s - - [%s] "%s %s %s" - %s'
     
-        f = StringIO()
+        f = BytesIO()
         
         class FakeSocket:
             def makefile(self, *a):

--- a/web/template.py
+++ b/web/template.py
@@ -1527,13 +1527,13 @@ def test():
         >>> t("$for k, v in sorted({'a': 1, 'b': 2}.items()):\n    $k $v", globals={'sorted':sorted})()
         u'a 1\nb 2\n'
         >>> t("$for k, v in ({'a': 1, 'b': 2}.items():\n    $k $v")()
-	Traceback (most recent call last):
-	...
-	SyntaxError: invalid syntax
-	<BLANKLINE>
-	Template traceback:
-	    File '<template>', line 6
-		None
+        Traceback (most recent call last):
+        ...
+        SyntaxError: invalid syntax
+        <BLANKLINE>
+        Template traceback:
+            File '<template>', line 6
+                None
 
     Test datetime.
 

--- a/web/template.py
+++ b/web/template.py
@@ -1317,10 +1317,7 @@ class TemplateResult(MutableMapping):
     
     def __str__(self):
         self._prepare_body()
-        if PY2:
-            return self["__body__"].encode('utf-8') 
-        else:
-            return self["__body__"]
+        return self["__body__"]
         
     def __repr__(self):
         self._prepare_body()

--- a/web/template.py
+++ b/web/template.py
@@ -1317,9 +1317,10 @@ class TemplateResult(MutableMapping):
     
     def __str__(self):
         self._prepare_body()
-        return self["__body__"]#.encode('utf-8') TODO needs testing
-        #In Py3 using "encode" will return bytes and not str
-        #Removing "encode" may induce errors with Py2, TBD
+        if PY2:
+            return self["__body__"].encode('utf-8') 
+        else:
+            return self["__body__"]
         
     def __repr__(self):
         self._prepare_body()

--- a/web/template.py
+++ b/web/template.py
@@ -1530,10 +1530,6 @@ def test():
         Traceback (most recent call last):
         ...
         SyntaxError: invalid syntax
-        <BLANKLINE>
-        Template traceback:
-            File '<template>', line 6
-                None
 
     Test datetime.
 

--- a/web/template.py
+++ b/web/template.py
@@ -1526,10 +1526,17 @@ def test():
         u'1\n2\n3\n4\n'
         >>> t("$for k, v in sorted({'a': 1, 'b': 2}.items()):\n    $k $v", globals={'sorted':sorted})()
         u'a 1\nb 2\n'
-        >>> t("$for k, v in ({'a': 1, 'b': 2}.items():\n    $k $v")()
-        Traceback (most recent call last):
+
+    Test for syntax error.
+
+        >>> try:
+        ...     t("$for k, v in ({'a': 1, 'b': 2}.items():\n    $k $v")()
+        ... except SyntaxError:
+        ...     print("OK")
+        ... else:
+        ...     print("Expected SyntaxError")
         ...
-        SyntaxError: invalid syntax
+        OK
 
     Test datetime.
 

--- a/web/test.py
+++ b/web/test.py
@@ -5,6 +5,8 @@ import unittest, doctest
 import sys, re
 import web
 
+from .py3helpers import PY2
+
 TestCase = unittest.TestCase
 TestSuite = unittest.TestSuite
 
@@ -24,13 +26,16 @@ def module_suite(module, classnames=None):
 #Source : Dirkjan Ochtman (https://dirkjan.ochtman.nl/writing/2014/07/06/single-source-python-23-doctests.html)
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
-        if sys.version_info[0] > 2:
+        if not PY2:
             #Differences between unicode strings representations : u"foo" -> "foo"
             want = re.sub("u'(.*?)'", "'\\1'", want) 
             want = re.sub('u"(.*?)"', '"\\1"', want)
 
             #NameError message has changed
             want = want.replace('NameError: global name', 'NameError: name')
+        else:
+            want = re.sub("^b'(.*?)'", "'\\1'", want) 
+            want = re.sub('^b"(.*?)"', '"\\1"', want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 def doctest_suite(module_names):

--- a/web/utils.py
+++ b/web/utils.py
@@ -1395,9 +1395,9 @@ class _EmailMessage:
         bcc = listify(kw.get('bcc', []))
         recipients = to_address + cc + bcc
 
-        import email.Utils
-        self.from_address = email.Utils.parseaddr(from_address)[1]
-        self.recipients = [email.Utils.parseaddr(r)[1] for r in recipients]        
+        import email.utils
+        self.from_address = email.utils.parseaddr(from_address)[1]
+        self.recipients = [email.utils.parseaddr(r)[1] for r in recipients]
     
         self.headers = dictadd({
           'From': from_address,
@@ -1416,7 +1416,7 @@ class _EmailMessage:
         self.multipart = False
         
     def new_message(self):
-        from email.Message import Message
+        from email.message import Message
         return Message()
         
     def attach(self, filename, content, content_type=None):
@@ -1433,7 +1433,7 @@ class _EmailMessage:
         except:
             from email import Encoders as encoders
             
-        content_type = content_type or mimetypes.guess_type(filename)[0] or "applcation/octet-stream"
+        content_type = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
         
         msg = self.new_message()
         msg.set_payload(content)
@@ -1456,13 +1456,13 @@ class _EmailMessage:
 
     def send(self):
         try:
-            import webapi
+            from . import webapi
         except ImportError:
             webapi = Storage(config=Storage())
 
         self.prepare_message()
         message_text = self.message.as_string()
-    
+
         if webapi.config.get('smtp_server'):
             server = webapi.config.get('smtp_server')
             port = webapi.config.get('smtp_port', 0)
@@ -1503,7 +1503,7 @@ class _EmailMessage:
             cmd = [sendmail, '-f', self.from_address] + self.recipients
 
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-            p.stdin.write(message_text)
+            p.stdin.write(message_text.encode('utf-8'))
             p.stdin.close()
             p.wait()
                 


### PR DESCRIPTION
In Py3, the data of the response sent to the WSGI server is now always in UTF8-encoded bytes.
I had to modify a bit the Browser class for it to handle this change.