### PR TITLE
Extended mapping: more types of URL mappings handled, views can be objects

### DIFF
--- a/web/webapi.py
+++ b/web/webapi.py
@@ -172,14 +172,14 @@ notfound = NotFound
 
 class NoMethod(HTTPError):
     """A `405 Method Not Allowed` error."""
-    def __init__(self, cls=None):
+    def __init__(self, obj=None):
         status = '405 Method Not Allowed'
         headers = {}
         headers['Content-Type'] = 'text/html'
 
         methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE']
-        if cls:
-            methods = [method for method in methods if hasattr(cls, method)]
+        if obj:
+            methods = [method for method in methods if hasattr(obj, method)]
 
         headers['Allow'] = ', '.join(methods)
         data = None


### PR DESCRIPTION
Two main goals :
- More types of URL mappings are now handled : beside tuples, it now handles a dict or a custom class
- Views can now be general objects (i.e. an instantiated class), and not mandatory a class anymore

This little commit enables more flexibility when writing web.py apps. We actualy need this for our INGInious tool (http://inginious.org/), where our views are splitted across different files, but need access to some constant parameters generated when the application is launched.

See the added tests for some examples of these features.