### PR TITLE
Fix: command line should has higher priority than environment variable

### DIFF
--- a/web/wsgi.py
+++ b/web/wsgi.py
@@ -52,9 +52,9 @@ def runwsgi(func):
             return runscgi(func)
     
     
-    server_addr = validip(listget(sys.argv, 1, ''))
-    if 'PORT' in os.environ: # e.g. Heroku
+    if 'PORT' in os.environ: # use PORT if available
         server_addr = ('0.0.0.0', intget(os.environ['PORT']))
+    server_addr = validip(listget(sys.argv, 1, ''))
     
     return httpserver.runsimple(func, server_addr)
     


### PR DESCRIPTION
Environment variable has the highest priority may bring some surprises to user
since user may not configured such PORT environment variable but command line
argument, but he found web.py listen at a unknown port rather than the port
specified by the user.

I think this is why almost of all programs follow this trandition in Linux
world.

Signed-off-by: Chengwei Yang yangchengwei@qiyi.com
