### PR TITLE
Fix DiskStore concurrency issue.

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -5,6 +5,7 @@ Session Management
 
 import os, time, datetime, random, base64
 import os.path
+import threading
 from copy import deepcopy
 try:
     import cPickle as pickle
@@ -254,13 +255,15 @@ class DiskStore(Store):
 
     def __setitem__(self, key, value):
         path = self._get_path(key)
-        pickled = self.encode(value)    
+        pickled = self.encode(value)
         try:
-            f = open(path, 'wb')
+            tname = path+"."+threading.current_thread().getName()
+            f = open(tname, 'w')
             try:
                 f.write(pickled)
-            finally: 
+            finally:
                 f.close()
+                os.rename(tname, path) # atomary operation
         except IOError:
             pass
 


### PR DESCRIPTION
DiskStore.__setitem__ is not atomary and a host of errors can be thrown under
load. This method has been made threadsafe.

From skawouter's web.py fork / PR 239
https://github.com/webpy/webpy/pull/239
