### PR TITLE
Fix a logical bug.

### DIFF
--- a/web/net.py
+++ b/web/net.py
@@ -126,7 +126,7 @@ def validip(ip, defaultaddr="0.0.0.0", defaultport=8080):
             raise ValueError(':'.join(ip) + ' is not a valid IP address/port')
     elif len(ip) == 2:
         addr, port = ip
-        if not validipaddr(addr) and validipport(port):
+        if not validipaddr(addr) or not validipport(port):
             raise ValueError(':'.join(ip) + ' is not a valid IP address/port')
         port = int(port)
     else:


### PR DESCRIPTION
"not" has higher precedence over "and" operator. So, expression "not x and y" != "not x or not y".

The target is to check if any of the addr and port are invalid, but the current expression is true when addr is invalid but port is valid.