### PR TITLE
Added support for SameSite cookies.

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -32,7 +32,8 @@ web.config.session_parameters = utils.storage({
     'secret_key': 'fLjUfxqXtfNoIldA0A0J',
     'expired_message': 'Session expired',
     'httponly': True,
-    'secure': False
+    'secure': False,
+    'samesite': None
 })
 
 class SessionExpired(web.HTTPError): 
@@ -143,7 +144,9 @@ class Session(object):
         cookie_path = self._config.cookie_path
         httponly = self._config.httponly
         secure = self._config.secure
-        web.setcookie(cookie_name, session_id, expires=expires, domain=cookie_domain, httponly=httponly, secure=secure, path=cookie_path)
+        samesite = self._config.samesite
+        web.setcookie(cookie_name, session_id, expires=expires, domain=cookie_domain,\
+                httponly=httponly, secure=secure, path=cookie_path, samesite=samesite)
     
     def _generate_session_id(self):
         """Generate a random id for session"""

--- a/web/session.py
+++ b/web/session.py
@@ -33,7 +33,7 @@ web.config.session_parameters = utils.storage({
     'expired_message': 'Session expired',
     'httponly': True,
     'secure': False,
-    'samesite': None
+    'samesite': None,
 })
 
 class SessionExpired(web.HTTPError): 

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -392,8 +392,9 @@ def setcookie(name, value, expires='', domain=None,
     if httponly:
         morsel["httponly"] = True
     value = morsel.OutputString()
-    if samesite and samesite.lower() in ["strict", "lax"]:
-        value += '; SameSite=' + samesite
+    if samesite and samesite.lower() in ['strict', 'lax']:
+        samesite_attr = "; SameSite=%s" % samesite
+        value += samesite_attr
     header('Set-Cookie', value)
 
 def decode_cookie(value):

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -376,7 +376,7 @@ def data():
     return ctx.data
 
 def setcookie(name, value, expires='', domain=None,
-              secure=False, httponly=False, path=None):
+              secure=False, httponly=False, path=None, samesite=None):
     """Sets a cookie."""
     morsel = Morsel()
     name, value = safestr(name), safestr(value)
@@ -389,9 +389,11 @@ def setcookie(name, value, expires='', domain=None,
         morsel['domain'] = domain
     if secure:
         morsel['secure'] = secure
-    value = morsel.OutputString()
     if httponly:
-        value += '; httponly'
+        morsel["httponly"] = True
+    value = morsel.OutputString()
+    if isinstance(samesite, basestring) and samesite.lower() in ["strict", "lax"]:
+        value += '; SameSite=' + samesite
     header('Set-Cookie', value)
 
 def decode_cookie(value):

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -392,7 +392,7 @@ def setcookie(name, value, expires='', domain=None,
     if httponly:
         morsel["httponly"] = True
     value = morsel.OutputString()
-    if isinstance(samesite, basestring) and samesite.lower() in ["strict", "lax"]:
+    if samesite and samesite.lower() in ["strict", "lax"]:
         value += '; SameSite=' + samesite
     header('Set-Cookie', value)
 


### PR DESCRIPTION
Good to mitigate against CSRF attacks. `SameSite` cookies are mentioned
in draft https://tools.ietf.org/html/draft-west-first-party-cookies-07

Fix for issue #410 