### PR TITLE
Updates .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.pyc
 .DS_Store
+build/
+dist/
+docs/_build/
+*.egg-info
+


### PR DESCRIPTION
The configuration now ignores Python eggs, build and dist directories.