### PR TITLE
typo in fastcgi

### DIFF
--- a/web/wsgi.py
+++ b/web/wsgi.py
@@ -31,7 +31,7 @@ def runwsgi(func):
         os.environ['FCGI_FORCE_CGI'] = 'Y'
 
     if ('PHP_FCGI_CHILDREN' in os.environ #lighttpd fastcgi
-      or 'SERVER_SOFTWARE') in os.environ:
+      or 'SERVER_SOFTWARE' in os.environ):
         return runfcgi(func, None)
     
     if 'fcgi' in sys.argv or 'fastcgi' in sys.argv:


### PR DESCRIPTION
parentheses are in the wrong place giving this error

```
  File "/usr/local/lib/python3.4/dist-packages/web/application.py", line 341, in run
    return wsgi.runwsgi(self.wsgifunc(*middleware))
  File "/usr/local/lib/python3.4/dist-packages/web/wsgi.py", line 34, in runwsgi
    or 'SERVER_SOFTWARE') in os.environ:
  File "/usr/lib/python3.4/_collections_abc.py", line 431, in __contains__
    self[key]
  File "/usr/lib/python3.4/os.py", line 630, in __getitem__
    value = self._data[self.encodekey(key)]
  File "/usr/lib/python3.4/os.py", line 706, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not bool
```