### PR TITLE
import SimpleCookie for compatibility with both python 2 and 3

### DIFF
--- a/test/application.py
+++ b/test/application.py
@@ -353,6 +353,41 @@ class ApplicationTest(webtest.TestCase):
         self.assertEquals(f(''), 'foo=bar; Path=/')
         self.assertEquals(f('/admin'), 'foo=bar; Path=/admin/')
 
+    def test_getcookie_fast(self):
+        urls = (
+            '/', 'index',
+        )
+
+        class index:
+            def GET(self):
+                return web.cookies().get('x')
+        app = web.application(urls, locals())
+
+        def f(script_name=""):
+            response = app.request("/", env={"SCRIPT_NAME": script_name},
+                                   headers={'Cookie': 'x=1'})
+            return response.data
+
+        self.assertEquals(f(''), b'1')
+
+    def test_getcookie_slow(self):
+        urls = (
+            '/', 'index',
+        )
+
+        class index:
+            def GET(self):
+                return web.cookies().get('x')
+        app = web.application(urls, locals())
+
+        def f(script_name=""):
+            # HTTP_COOKIE has quotes in it.
+            response = app.request("/", env={"SCRIPT_NAME": script_name},
+                                   headers={'Cookie': 'x="1"'})
+            return response.data
+
+        self.assertEquals(f(''), b'1')
+
     def test_stopsimpleserver(self):
         urls = (
             '/', 'index',

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -36,10 +36,10 @@ from .py3helpers import PY2, urljoin, string_types
 
 try:
     from urllib.parse import unquote, quote
-    from http.cookies import Morsel, SimpleCookie
+    from http.cookies import Morsel, SimpleCookie, CookieError
 except ImportError:
     from urllib import unquote, quote
-    from Cookie import Morsel, SimpleCookie
+    from Cookie import Morsel, SimpleCookie, CookieError
 
 from io import StringIO, BytesIO
 
@@ -447,14 +447,14 @@ def parse_cookies(http_cookie):
         cookie = SimpleCookie()
         try:
             cookie.load(http_cookie)
-        except Cookie.CookieError:
+        except CookieError:
             # If HTTP_COOKIE header is malformed, try at least to load the cookies we can by
             # first splitting on ';' and loading each attr=value pair separately
             cookie = SimpleCookie()
             for attr_value in http_cookie.split(';'):
                 try:
                     cookie.load(attr_value)
-                except Cookie.CookieError:
+                except CookieError:
                     pass
         cookies = dict([(k, unquote(v.value)) for k, v in cookie.items()])
     else:

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -36,10 +36,10 @@ from .py3helpers import PY2, urljoin, string_types
 
 try:
     from urllib.parse import unquote, quote
-    from http.cookies import Morsel
+    from http.cookies import Morsel, SimpleCookie
 except ImportError:
     from urllib import unquote, quote
-    from Cookie import Morsel
+    from Cookie import Morsel, SimpleCookie
 
 from io import StringIO, BytesIO
 
@@ -444,19 +444,19 @@ def parse_cookies(http_cookie):
     #print "parse_cookies"
     if '"' in http_cookie:
         # HTTP_COOKIE has quotes in it, use slow but correct cookie parsing
-        cookie = Cookie.SimpleCookie()
+        cookie = SimpleCookie()
         try:
             cookie.load(http_cookie)
         except Cookie.CookieError:
             # If HTTP_COOKIE header is malformed, try at least to load the cookies we can by
             # first splitting on ';' and loading each attr=value pair separately
-            cookie = Cookie.SimpleCookie()
+            cookie = SimpleCookie()
             for attr_value in http_cookie.split(';'):
                 try:
                     cookie.load(attr_value)
                 except Cookie.CookieError:
                     pass
-        cookies = dict([(k, unquote(v.value)) for k, v in cookie.iteritems()])
+        cookies = dict([(k, unquote(v.value)) for k, v in cookie.items()])
     else:
         # HTTP_COOKIE doesn't have quotes, use fast cookie parsing
         cookies = {}


### PR DESCRIPTION
Simple fix to import SimpleCookie rather than the previous Cookie.SimpleCookie().

Also switched from cookie.iteritems() to cookie.items.