### PR TITLE
Replace Cookie with http.cookies when using Py3

### DIFF
--- a/web/webapi.py
+++ b/web/webapi.py
@@ -456,7 +456,7 @@ def parse_cookies(http_cookie):
                     cookie.load(attr_value)
                 except CookieError:
                     pass
-        cookies = dict([(k, unquote(v.value)) for k, v in cookie.iteritems()])
+        cookies = dict([(k, unquote(v.value)) for k, v in cookie.items()])
     else:
         # HTTP_COOKIE doesn't have quotes, use fast cookie parsing
         cookies = {}

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -36,10 +36,10 @@ from .py3helpers import PY2, urljoin, string_types
 
 try:
     from urllib.parse import unquote, quote
-    from http.cookies import Morsel
+    from http.cookies import Morsel, SimpleCookie, CookieError
 except ImportError:
     from urllib import unquote, quote
-    from Cookie import Morsel
+    from Cookie import Morsel, SimpleCookie, CookieError
 
 from io import StringIO, BytesIO
 
@@ -444,17 +444,17 @@ def parse_cookies(http_cookie):
     #print "parse_cookies"
     if '"' in http_cookie:
         # HTTP_COOKIE has quotes in it, use slow but correct cookie parsing
-        cookie = Cookie.SimpleCookie()
+        cookie = SimpleCookie()
         try:
             cookie.load(http_cookie)
-        except Cookie.CookieError:
+        except CookieError:
             # If HTTP_COOKIE header is malformed, try at least to load the cookies we can by
             # first splitting on ';' and loading each attr=value pair separately
-            cookie = Cookie.SimpleCookie()
+            cookie = SimpleCookie()
             for attr_value in http_cookie.split(';'):
                 try:
                     cookie.load(attr_value)
-                except Cookie.CookieError:
+                except CookieError:
                     pass
         cookies = dict([(k, unquote(v.value)) for k, v in cookie.iteritems()])
     else:


### PR DESCRIPTION
A part of web.py still uses `Cookie` which has been renamed as `http.cookies` in Py3, leading to an exception when calling this particular part of the code.

From UCL-INGI/INGInious#208 :
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/web/wsgiserver/wsgiserver3.py", line 1089, in communicate
    req.respond()
  File "/usr/local/lib/python3.5/dist-packages/web/wsgiserver/wsgiserver3.py", line 877, in respond
    self.server.gateway(self).respond()
  File "/usr/local/lib/python3.5/dist-packages/web/wsgiserver/wsgiserver3.py", line 1980, in respond
    response = self.req.server.wsgi_app(self.env, self.start_response)
  File "/usr/local/lib/python3.5/dist-packages/inginious/common/log.py", line 47, in __call__
    return self.app(environ, xstart_response)
  File "/usr/local/lib/python3.5/dist-packages/inginious/frontend/common/static_middleware.py", line 64, in __call__
    return self.app(environ, start_response)
  File "/usr/local/lib/python3.5/dist-packages/web/application.py", line 295, in wsgi
    result = self.handle_with_processors()
  File "/usr/local/lib/python3.5/dist-packages/web/application.py", line 267, in handle_with_processors
    return process(self.processors)
  File "/usr/local/lib/python3.5/dist-packages/web/application.py", line 264, in process
    raise self.internalerror()
  File "/usr/local/lib/python3.5/dist-packages/web/application.py", line 545, in internalerror
    return debugerror()
  File "/usr/local/lib/python3.5/dist-packages/web/debugerror.py", line 313, in debugerror
    return web._InternalError(djangoerror())
  File "/usr/local/lib/python3.5/dist-packages/web/debugerror.py", line 303, in djangoerror
    return t(exception_type, exception_value, frames)
  File "/usr/local/lib/python3.5/dist-packages/web/template.py", line 904, in __call__
    return BaseTemplate.__call__(self, *a, **kw)
  File "/usr/local/lib/python3.5/dist-packages/web/template.py", line 831, in __call__
    return self.t(*a, **kw)
  File "/usr/local/lib/python3.5/dist-packages/web/debugerror.py", line 196, in __template__
    </ul>
  File "/usr/local/lib/python3.5/dist-packages/web/webapi.py", line 487, in cookies
    ctx._parsed_cookies = parse_cookies(http_cookie)
  File "/usr/local/lib/python3.5/dist-packages/web/webapi.py", line 447, in parse_cookies
    cookie = Cookie.SimpleCookie()
NameError: name 'Cookie' is not defined
```