### PR TITLE
Fixed the travis build error caused by mysql-connector

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
 psycopg2
 PyMySQL
-mysql-connector
+mysql-connector==2.1.4
 DBUtils


### PR DESCRIPTION
Using mysql-connector==2.1.4 to fix the build error in installing that library.

Installing the new versions of mysql-connector library was failing in
Travis build as that depends on protobuf which was not available.
Forcing a lower version to resolve that issue.

Closes #424