### PR TITLE
Templates load error in Python3

### DIFF
--- a/web/template.py
+++ b/web/template.py
@@ -1013,7 +1013,7 @@ class Render:
         if kind == 'dir':
             return Render(path, cache=self._cache is not None, base=self._base, **self._keywords)
         elif kind == 'file':
-            return Template(open(path).read(), filename=path, **self._keywords)
+            return Template(open(path,encoding='utf-8').read(), filename=path, **self._keywords)
         else:
             raise AttributeError("No template named " + name)
 

--- a/web/template.py
+++ b/web/template.py
@@ -1013,7 +1013,7 @@ class Render:
         if kind == 'dir':
             return Render(path, cache=self._cache is not None, base=self._base, **self._keywords)
         elif kind == 'file':
-            return Template(open(path,encoding='utf-8').read(), filename=path, **self._keywords)
+            return Template(open(path, encoding='utf-8').read(), filename=path, **self._keywords)
         else:
             raise AttributeError("No template named " + name)
 


### PR DESCRIPTION
Templates load error in Python3
![_2_9 20xx wf wg x s](https://user-images.githubusercontent.com/12872668/27983408-b9153ce2-63ed-11e7-822e-1630aa5792b5.png)
![p _ 8 v o84 1mr5e4 ouxh](https://user-images.githubusercontent.com/12872668/27983427-58d8804a-63ee-11e7-96a3-8fe2e37c5c47.png)

I fix it by adding  encoding='utf-8'