### PR TITLE
Ensure app module is picked up by Reloader.

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -97,6 +97,9 @@ class application:
 
             self.add_processor(loadhook(Reloader()))
             if mapping_name and module_name:
+                # when app is ran as part of a package, this puts the app into sys.modules correctly.
+                # without it, the first change to the app module will not be picked up by Reloader
+                reload_mapping()
                 self.add_processor(loadhook(reload_mapping))
 
             # load __main__ module usings its filename, so that it can be reloaded.


### PR DESCRIPTION
When app is part of a package (e.g. project/app.py), the first
time a change is made to app.py, it was previously not picked up
by Reloader since the app.py module was not found in sys.modules

Steps to recreate
1. Unzip the attached sample app (initial-reload-bug.zip)
2. Setup virtualenv (make init)
3. Run the application (make web)
4. Either in a web browser or a terminal go to http://localhost:8090 - You should see "Hello world!"
5. Edit file project/app.py and change "Hello world!" to "Goodbye world!". Save the file
6. Repeat step 4. You will still see "Hello world!". This is not correct. "Goodbye world!" should have been displayed.
7. Save project/app.py again
8. Repeat step 4. You will now see "Goodbye world!"

After applying the change set, Repeat steps from above (adjust step 2 to ensure correct path to patched web.py or edit requirements.txt). Step 6 will now say "Goodbye world!"



[initial-reload-bug.zip](https://github.com/webpy/webpy/files/1293903/initial-reload-bug.zip)


