### PR TITLE
Add reload support for package based apps when ran as a module.

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -70,7 +70,11 @@ class application:
             def main_module_name():
                 mod = sys.modules['__main__']
                 file = getattr(mod, '__file__', None) # make sure this works even from python interpreter
-                return file and os.path.splitext(os.path.basename(file))[0]
+                package = getattr(mod, '__package__', None) # handles python -m package.app
+                if not file:
+                    return False
+                modname = os.path.splitext(os.path.basename(file))[0]
+                return "%s.%s" % (package, modname) if package else modname
 
             def modname(fvars):
                 """find name of the module name from fvars."""


### PR DESCRIPTION
When running a web.py app like python -m project/app.py reloader throws an ImportError.

To recreate:

1. unzip the sample app (reload-module-app.zip)
2. run make clean init web to set things up or if you have a virtualenv and web.py already installed, run python -m project/app.py 8090
3. visit http://localhost:8090 - will receive an HTTP 500 due to an ImportError
4. Apply the patch and visit localhost:8090 again. Request no longer results in an ImportError

[reload-module-app.zip](https://github.com/webpy/webpy/files/1294074/reload-module-app.zip)
