### PR TITLE
allow HTML5 form input elements

### DIFF
--- a/web/form.py
+++ b/web/form.py
@@ -122,6 +122,11 @@ class Form(object):
     d = property(_get_d)
 
 class Input(object):
+    """Generic input. Type attribute must be specified when called directly
+
+        >>> Input(name='foo', value='bar', type='number').render()
+        u'<input id="foo" name="foo" value="bar" type="number"/>'
+    """
     def __init__(self, name, *validators, **attrs):
         self.name = name
         self.validators = validators
@@ -132,6 +137,7 @@ class Input(object):
         self.pre = attrs.pop('pre', "")
         self.post = attrs.pop('post', "")
         self.note = None
+        self.type = attrs.pop('type', None)
         
         self.id = attrs.setdefault('id', self.get_default_id())
         
@@ -143,7 +149,10 @@ class Input(object):
         return False
         
     def get_type(self):
-        raise NotImplementedError()
+        if self.type != None:
+            return self.type
+        else:
+            raise AttributeError("missing attribute 'type'")
         
     def get_default_id(self):
         return self.name

--- a/web/form.py
+++ b/web/form.py
@@ -124,8 +124,8 @@ class Form(object):
 class Input(object):
     """Generic input. Type attribute must be specified when called directly
 
-        >>> Input(name='foo', value='bar', type='number').render()
-        u'<input id="foo" name="foo" value="bar" type="number"/>'
+        >>> Input('foo', type='number', value="bar").render()
+        u'<input id="foo" name="foo" type="number" value="bar"/>'
     """
     def __init__(self, name, *validators, **attrs):
         self.name = name


### PR DESCRIPTION
HTML5 now allows for 13 additional <input /> elements from the original HTML4 spec, like 'email', 'tel', 'date', etc.  All modern browsers support them, and they give a better user experience with intuitive widgets and basic client-side error checking.

Each new input type is defined by declaring a type attribute on an input element, e.g. `<input name="foo" type="date"/>`.  Rather than creating specific classes for all 13 of them, which would be difficult to remember and greatly expand the code base, I propose modifying the generic Input element so it allows a type element to be passed as an input to the class; i.e. `web.form.Input(name="foo", type="date")`.  This will prevent having to update form.py in the future if/when other new input types are added.

I did not include any check to see if the type is a valid HTML5 form type.  I can include a list of valid types to check against, but this would again become invalid if/when the set of valid HTML5 input types is extended.