### PR TITLE
fix DeprecationWarning: generator 'IterBetter.__iter__' raised StopIteration for Python 3.5+

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -664,10 +664,12 @@ class IterBetter:
     def __iter__(self): 
         if hasattr(self, "_head"):
             yield self._head
-
-        while 1:    
-            yield next(self.i)
+        
+        # Fix DeprecationWarning: generator raised StopIteration, see PEP479
+        for x in self.i:
+            yield x
             self.c += 1
+        return
 
     def __getitem__(self, i):
         #todo: slices


### PR DESCRIPTION
Issue: DeprecationWarning: generator 'IterBetter.__iter__' raised StopIteration

My change is based on the example from [PEP 479: Change StopIteration handling inside generators](https://www.python.org/dev/peps/pep-0479/#examples-of-breakage)
OLD:
```python
if context is None:
    while True:
        yield next(line_pair_iterator)
```
Becomes:
```python
if context is None:
    for line in line_pair_iterator:
        yield line
    return
```