### PR TITLE
Fix Checkbox.get_value() always returning False

### DIFF
--- a/web/form.py
+++ b/web/form.py
@@ -353,7 +353,7 @@ class Checkbox(Input):
         return '<input %s/>' % attrs
 
     def set_value(self, value):
-        self.checked = bool(value)
+        self.checked = value is not None and value is not False
 
     def get_value(self):
         return self.checked


### PR DESCRIPTION
This should fix issue #273

Short explanation: this function gets called with an empty string for checked checkboxes and with None for unchecked ones, so both `bool('')` and `bool(None)` (the old code) return False.