### PR TITLE
Fix StopIteration error in utils for Python 3.7.0

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -521,18 +521,7 @@ def group(seq, size):
         >>> list(group([1,2,3,4,5], 2))
         [[1, 2], [3, 4], [5]]
     """
-    def take(seq, n):
-        for i in range(n):
-            yield next(seq)
-
-    if not hasattr(seq, 'next'):  
-        seq = iter(seq)
-    while True: 
-        x = list(take(seq, size))
-        if x:
-            yield x
-        else:
-            break
+    return (seq[i:i+size] for i in range(0, len(seq), size))
 
 def uniq(seq, key=None):
     """


### PR DESCRIPTION
In Python 3.7.0 implicitly breaking on StopIteration is no longer valid and transforms into a RuntimeError. This change now uses a simpler generator without the need to yield and rely on a StopIteration exception.