### PR TITLE
Race condition in DiskStore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.7-dev"
 install:
     - pip install -r requirements.txt -r test_requirements.txt
-    - if [[ $TRAVIS_PYTHON_VERSION = 2* ]] ; then pip install -r test/requirements2.txt; fi
 script: ./runtests.sh
 before_install:
   - "sudo mkdir -p /usr/include/postgresql/8.4/server"


### PR DESCRIPTION
I found a race condition between the methods setitem and getitem. Sometimes when the method getitem is called, the file containing the session data is not complete because it is still being written by another thread.

I fixed the problem by adding a recursive lock to the class and modifying the methods setitem and getitem so they acquire the lock before trying to read or write the session file.