### PR TITLE
Travis CI: Upgrade from prerelease Python 3.7 to release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
     - pip install -r requirements.txt -r test_requirements.txt
 script: ./runtests.sh


### PR DESCRIPTION
Upgrade to the production version of Python 3.7 in alignment with travis-ci/travis-ci#9069

Also see the note about outdated Python versions at:
* https://docs.travis-ci.com/user/languages/python/#development-releases-support

Needs #468