### PR TITLE
Fix CookieError and SimpleCookie for Python 2 & 3

### DIFF
--- a/web/webapi.py
+++ b/web/webapi.py
@@ -36,10 +36,10 @@ from .py3helpers import PY2, urljoin, string_types
 
 try:
     from urllib.parse import unquote, quote
-    from http.cookies import Morsel
+    from http.cookies import CookieError, Morsel, SimpleCookie
 except ImportError:
     from urllib import unquote, quote
-    from Cookie import Morsel
+    from Cookie import CookieError, Morsel, SimpleCookie
 
 from io import StringIO, BytesIO
 
@@ -444,17 +444,17 @@ def parse_cookies(http_cookie):
     #print "parse_cookies"
     if '"' in http_cookie:
         # HTTP_COOKIE has quotes in it, use slow but correct cookie parsing
-        cookie = Cookie.SimpleCookie()
+        cookie = SimpleCookie()
         try:
             cookie.load(http_cookie)
-        except Cookie.CookieError:
+        except CookieError:
             # If HTTP_COOKIE header is malformed, try at least to load the cookies we can by
             # first splitting on ';' and loading each attr=value pair separately
-            cookie = Cookie.SimpleCookie()
+            cookie = SimpleCookie()
             for attr_value in http_cookie.split(';'):
                 try:
                     cookie.load(attr_value)
-                except Cookie.CookieError:
+                except CookieError:
                     pass
         cookies = dict([(k, unquote(v.value)) for k, v in cookie.iteritems()])
     else:


### PR DESCRIPTION
flake8 testing of https://github.com/webpy/webpy on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./experimental/background.py:10:31: F821 undefined name 'threading'
        tmpctx = web._context[threading.currentThread()]
                              ^
./experimental/background.py:11:22: F821 undefined name 'threading'
        web._context[threading.currentThread()] = utils.storage(web.ctx.copy())
                     ^
./experimental/background.py:14:26: F821 undefined name 'threading'
            web._context[threading.currentThread()] = tmpctx
                         ^
./experimental/background.py:16:34: F821 undefined name 'threading'
            myctx = web._context[threading.currentThread()]
                                 ^
./experimental/background.py:22:13: F821 undefined name 'threading'
        t = threading.Thread(target=newfunc)
            ^
./experimental/background.py:26:16: F821 undefined name 'seeother'
        return seeother(changequery(_t=id(t)))
               ^
./experimental/background.py:26:25: F821 undefined name 'changequery'
        return seeother(changequery(_t=id(t)))
                        ^
./experimental/background.py:38:26: F821 undefined name 'threading'
            web._context[threading.currentThread()] = web._context[t]
                         ^
./web/utils.py:1249:16: F821 undefined name 'iterkeys'
        return iterkeys(self.__dict__)
               ^
./web/webapi.py:447:18: F821 undefined name 'Cookie'
        cookie = Cookie.SimpleCookie()
                 ^
./web/webapi.py:450:16: F821 undefined name 'Cookie'
        except Cookie.CookieError:
               ^
./web/webapi.py:453:22: F821 undefined name 'Cookie'
            cookie = Cookie.SimpleCookie()
                     ^
./web/webapi.py:457:24: F821 undefined name 'Cookie'
                except Cookie.CookieError:
                       ^
./web/httpserver.py:51:23: F821 undefined name 'SimpleHTTPServer'
    class WSGIHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                      ^
./web/httpserver.py:116:17: F821 undefined name 'SimpleHTTPServer'
                SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
                ^
./web/debugerror.py:360:13: F821 undefined name 'thisdoesnotexist'
            thisdoesnotexist
            ^
16    F821 undefined name 'threading'
16
```