### PR TITLE
Fix the usage of SimpleHTTPRequestHandler to match the imports

### DIFF
--- a/web/httpserver.py
+++ b/web/httpserver.py
@@ -9,11 +9,11 @@ from . import net
 from . import utils
 from .py3helpers import PY2
 
-if PY2:
+try:
+    from http.server import HTTPServer, SimpleHTTPRequestHandler, BaseHTTPRequestHandler
+except ImportError:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
-else:
-    from http.server import HTTPServer, SimpleHTTPRequestHandler, BaseHTTPRequestHandler
 
 try:
     from urllib import parse as urlparse
@@ -48,7 +48,7 @@ def runbasic(func, server_address=("0.0.0.0", 8080)):
     import socket, errno
     import traceback
 
-    class WSGIHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    class WSGIHandler(SimpleHTTPRequestHandler):
         def run_wsgi_app(self):
             protocol, host, path, parameters, query, fragment = \
                 urlparse.urlparse('http://dummyhost%s' % self.path)
@@ -113,7 +113,7 @@ def runbasic(func, server_address=("0.0.0.0", 8080)):
 
         def do_GET(self):
             if self.path.startswith('/static/'):
-                SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
+                SimpleHTTPRequestHandler.do_GET(self)
             else:
                 self.run_wsgi_app()
 


### PR DESCRIPTION
flake8 testing of https://github.com/webpy/webpy on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./experimental/background.py:10:31: F821 undefined name 'threading'
        tmpctx = web._context[threading.currentThread()]
                              ^
./experimental/background.py:11:22: F821 undefined name 'threading'
        web._context[threading.currentThread()] = utils.storage(web.ctx.copy())
                     ^
./experimental/background.py:14:26: F821 undefined name 'threading'
            web._context[threading.currentThread()] = tmpctx
                         ^
./experimental/background.py:16:34: F821 undefined name 'threading'
            myctx = web._context[threading.currentThread()]
                                 ^
./experimental/background.py:22:13: F821 undefined name 'threading'
        t = threading.Thread(target=newfunc)
            ^
./experimental/background.py:26:16: F821 undefined name 'seeother'
        return seeother(changequery(_t=id(t)))
               ^
./experimental/background.py:26:25: F821 undefined name 'changequery'
        return seeother(changequery(_t=id(t)))
                        ^
./experimental/background.py:38:26: F821 undefined name 'threading'
            web._context[threading.currentThread()] = web._context[t]
                         ^
./web/utils.py:1249:16: F821 undefined name 'iterkeys'
        return iterkeys(self.__dict__)
               ^
./web/webapi.py:447:18: F821 undefined name 'Cookie'
        cookie = Cookie.SimpleCookie()
                 ^
./web/webapi.py:450:16: F821 undefined name 'Cookie'
        except Cookie.CookieError:
               ^
./web/webapi.py:453:22: F821 undefined name 'Cookie'
            cookie = Cookie.SimpleCookie()
                     ^
./web/webapi.py:457:24: F821 undefined name 'Cookie'
                except Cookie.CookieError:
                       ^
./web/httpserver.py:51:23: F821 undefined name 'SimpleHTTPServer'
    class WSGIHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                      ^
./web/httpserver.py:116:17: F821 undefined name 'SimpleHTTPServer'
                SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
                ^
./web/debugerror.py:360:13: F821 undefined name 'thisdoesnotexist'
            thisdoesnotexist
            ^
16    F821 undefined name 'threading'
16
```