### PR TITLE
Travis CI: 'sudo' is no longer required by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
   include:
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 before_install:
   - sudo mkdir -p /usr/include/postgresql/8.4/server
 # - 'sudo apt-get -o Dpkg::Options::="--force-overwrite" install python-profiler'


### PR DESCRIPTION
[Travis are now recommending removing __sudo__](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)