### PR TITLE
Add comment line to bypass Black format if URLs contain multiple patterns.

### DIFF
--- a/experimental/pwt.py
+++ b/experimental/pwt.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 import web
 import simplejson, sudo
+
+# fmt: off
 urls = (
     '/sudo', 'sudoku',
     '/length', 'length',

--- a/experimental/pwt.py
+++ b/experimental/pwt.py
@@ -7,6 +7,7 @@ urls = (
     '/sudo', 'sudoku',
     '/length', 'length',
 )
+# fmt: on
 
 
 class pwt(object):

--- a/experimental/untwisted.py
+++ b/experimental/untwisted.py
@@ -96,6 +96,7 @@ class JSFeed(Feed):
 if __name__ == "__main__":
     mfeed = JSFeed()
 
+    # fmt: off
     urls = (
       '/', 'view',
       '/js', 'js',

--- a/experimental/untwisted.py
+++ b/experimental/untwisted.py
@@ -98,10 +98,11 @@ if __name__ == "__main__":
 
     # fmt: off
     urls = (
-      '/', 'view',
-      '/js', 'js',
-      '/send', 'send'
+        '/', 'view',
+        '/js', 'js',
+        '/send', 'send'
     )
+    # fmt: on
 
     class view:
         def GET(self):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -76,6 +76,8 @@ class ApplicationTest(unittest.TestCase):
             "/b/(.*)", r"redirect /hello/\1",
             "/hello/(.*)", "hello"
         )
+        # fmt: on
+
         app = web.application(urls, locals())
         class hello:
             def GET(self, name):
@@ -122,6 +124,8 @@ class ApplicationTest(unittest.TestCase):
             "/blog", app_blog,
             "/(.*)", "index"
         )
+        # fmt: on
+
         class index:
             def GET(self, path):
                 return "hello " + path
@@ -149,6 +153,8 @@ class ApplicationTest(unittest.TestCase):
             "b.example.com", create_app('b'),
             ".*.example.com", create_app('*')
         )
+        # fmt: on
+
         app = web.subdomain_application(urls, locals())
 
         def test(host, expected_result):
@@ -177,6 +183,8 @@ class ApplicationTest(unittest.TestCase):
             "/blog", app_blog,
             "/(.*)", "index"
         )
+        # fmt: on
+
         class index:
             def GET(self, path):
                 return "hello " + path
@@ -214,6 +222,8 @@ class ApplicationTest(unittest.TestCase):
             "/blog", app_blog,
             "/(.*)", "index"
         )
+        # fmt: on
+
         class index:
             def GET(self, path):
                 return "hello " + path
@@ -280,6 +290,8 @@ class ApplicationTest(unittest.TestCase):
             "/a", app_a,
             "/b", app_b
         )
+        # fmt: on
+
         app = web.application(urls, locals())
 
         def assert_notfound(path, message):
@@ -309,6 +321,8 @@ class ApplicationTest(unittest.TestCase):
             "/foo", "foo",
             "/bar", "bar"
         )
+        # fmt: on
+
         class foo:
             def GET(self):
                 return "foo"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -70,6 +70,7 @@ class ApplicationTest(unittest.TestCase):
         self.assertEqual(response.status, '405 Method Not Allowed')
 
     def testRedirect(self):
+        # fmt: off
         urls = (
             "/a", "redirect /hello/",
             "/b/(.*)", r"redirect /hello/\1",
@@ -116,6 +117,7 @@ class ApplicationTest(unittest.TestCase):
                 return "blog " + path
         app_blog = web.application(urls, locals())
 
+        # fmt: off
         urls = (
             "/blog", app_blog,
             "/(.*)", "index"
@@ -141,6 +143,7 @@ class ApplicationTest(unittest.TestCase):
                     return name
             return web.application(urls, locals())
 
+        # fmt: off
         urls = (
             "a.example.com", create_app('a'),
             "b.example.com", create_app('b'),
@@ -169,6 +172,7 @@ class ApplicationTest(unittest.TestCase):
                     raise web.seeother('/bar')
         app_blog = web.application(urls, locals())
 
+        # fmt: off
         urls = (
             "/blog", app_blog,
             "/(.*)", "index"
@@ -205,6 +209,7 @@ class ApplicationTest(unittest.TestCase):
         app_blog = web.application(urls, locals())
         app_blog.add_processor(web.loadhook(f))
 
+        # fmt: off
         urls = (
             "/blog", app_blog,
             "/(.*)", "index"
@@ -270,6 +275,7 @@ class ApplicationTest(unittest.TestCase):
 
         app_a.notfound = lambda: web.HTTPError("404 Not Found", {}, "not found 1")
 
+        # fmt: off
         urls = (
             "/a", app_a,
             "/b", app_b
@@ -298,6 +304,7 @@ class ApplicationTest(unittest.TestCase):
     def testUnload(self):
         x = web.storage(a=0)
 
+        # fmt: off
         urls = (
             "/foo", "foo",
             "/bar", "bar"

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,6 +1,7 @@
 import unittest
 import web
 
+# fmt: off
 urls = (
     "/", "index",
     "/hello/(.*)", "hello",

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -9,6 +9,8 @@ urls = (
     "/setcookie", "setcookie",
     "/redirect", "redirect",
 )
+# fmt: on
+
 app = web.application(urls, globals())
 
 class index:


### PR DESCRIPTION
Add comment line `# fmt: off` for `urls = ()` which contain multiple patterns to bypass Black formatter.