### PR TITLE
Remove legacy code and improve cookie support

### DIFF
--- a/web/browser.py
+++ b/web/browser.py
@@ -290,6 +290,7 @@ class AppHandler(HTTPHandler):
     """urllib2 handler to handle requests using web.py application."""
 
     handler_order = 100
+    https_request = HTTPHandler.do_request_
 
     def __init__(self, app):
         self.app = app
@@ -307,12 +308,6 @@ class AppHandler(HTTPHandler):
 
     def https_open(self, req):
         return self.http_open(req)
-
-    try:
-        https_request = HTTPHandler.do_request_
-    except AttributeError:
-        # for python 2.3
-        pass
 
     def _make_response(self, result, url):
 

--- a/web/form.py
+++ b/web/form.py
@@ -17,7 +17,7 @@ def attrget(obj, attr, value=None):
         # This is the case with Model objects on appengine. See #134
         pass
     if (
-        hasattr(obj, "keys") and attr in obj.keys()
+        hasattr(obj, "keys") and attr in obj
     ):  # needed for Py3, has_key doesn't exist anymore
         return obj[attr]
     elif hasattr(obj, attr):

--- a/web/http.py
+++ b/web/http.py
@@ -77,12 +77,6 @@ def modified(date=None, etag=None):
     `True`, or otherwise it raises NotModified error. It also sets
     `Last-Modified` and `ETag` output headers.
     """
-    try:
-        from __builtin__ import set
-    except ImportError:
-        # for python 2.3
-        from sets import Set as set
-
     n = set(
         [x.strip('" ') for x in web.ctx.env.get("HTTP_IF_NONE_MATCH", "").split(",")]
     )

--- a/web/session.py
+++ b/web/session.py
@@ -162,7 +162,7 @@ class Session(object):
         cookie_path = self._config.cookie_path
         httponly = self._config.httponly
         secure = self._config.secure
-        samesite = kw.get("samesite", None) or self._config.get("samesite", None)
+        samesite = kw.get("samesite", self._config.get("samesite", None))
         web.setcookie(
             cookie_name,
             session_id,

--- a/web/session.py
+++ b/web/session.py
@@ -28,6 +28,7 @@ web.config.session_parameters = utils.storage(
         "cookie_name": "webpy_session_id",
         "cookie_domain": None,
         "cookie_path": None,
+        "samesite": None,
         "timeout": 86400,  # 24 * 60 * 60, # 24 hours in seconds
         "ignore_expiry": True,
         "ignore_change_ip": True,
@@ -149,7 +150,11 @@ class Session(object):
             self.store[self.session_id] = dict(self._data)
         else:
             if web.cookies().get(self._config.cookie_name):
-                self._setcookie(self.session_id, expires=self._config.timeout)
+                self._setcookie(
+                    self.session_id,
+                    expires=self._config.timeout,
+                    samesite=self._config.get("samesite"),
+                )
 
     def _setcookie(self, session_id, expires="", **kw):
         cookie_name = self._config.cookie_name
@@ -157,6 +162,7 @@ class Session(object):
         cookie_path = self._config.cookie_path
         httponly = self._config.httponly
         secure = self._config.secure
+        samesite = kw.get("samesite", None) or self._config.get("samesite", None)
         web.setcookie(
             cookie_name,
             session_id,
@@ -165,6 +171,7 @@ class Session(object):
             httponly=httponly,
             secure=secure,
             path=cookie_path,
+            samesite=samesite,
         )
 
     def _generate_session_id(self):

--- a/web/session.py
+++ b/web/session.py
@@ -387,7 +387,7 @@ class ShelfStore:
 
     def cleanup(self, timeout):
         now = time.time()
-        for k in self.shelf.keys():
+        for k in self.shelf:
             atime, v = self.shelf[k]
             if now - atime > timeout:
                 del self[k]

--- a/web/session.py
+++ b/web/session.py
@@ -149,7 +149,7 @@ class Session(object):
             self.store[self.session_id] = dict(self._data)
         else:
             if web.cookies().get(self._config.cookie_name):
-                self._setcookie(self.session_id, expires=-1)
+                self._setcookie(self.session_id, expires=self._config.timeout)
 
     def _setcookie(self, session_id, expires="", **kw):
         cookie_name = self._config.cookie_name
@@ -160,7 +160,7 @@ class Session(object):
         web.setcookie(
             cookie_name,
             session_id,
-            expires=expires,
+            expires=expires or self._config.timeout,
             domain=cookie_domain,
             httponly=httponly,
             secure=secure,

--- a/web/utils.py
+++ b/web/utils.py
@@ -1243,18 +1243,6 @@ class Profile:
 profile = Profile
 
 
-# hack for compatibility with Python 2.3:
-if not hasattr(traceback, "format_exc"):
-    from cStringIO import StringIO
-
-    def format_exc(limit=None):
-        strbuf = StringIO()
-        traceback.print_exc(limit, strbuf)
-        return strbuf.getvalue()
-
-    traceback.format_exc = format_exc
-
-
 def tryall(context, prefix=None):
     """
     Tries a series of functions and prints their results.

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -420,7 +420,7 @@ def rawinput(method=None):
         if fs.list is None:
             fs.list = []
 
-        return dict([(k, fs[k]) for k in fs.keys()])
+        return dict([(k, fs[k]) for k in fs])
 
     e = ctx.env.copy()
     a = b = {}

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -485,7 +485,14 @@ def data():
 
 
 def setcookie(
-    name, value, expires="", domain=None, secure=False, httponly=False, path=None
+    name,
+    value,
+    expires="",
+    domain=None,
+    secure=False,
+    httponly=False,
+    path=None,
+    samesite=None,
 ):
     """Sets a cookie."""
     morsel = Morsel()
@@ -499,9 +506,11 @@ def setcookie(
         morsel["domain"] = domain
     if secure:
         morsel["secure"] = secure
-    value = morsel.OutputString()
     if httponly:
-        value += "; httponly"
+        morsel["httponly"] = True
+    value = morsel.OutputString()
+    if samesite and samesite.lower() in ["strict", "lax"]:
+        value += "; SameSite=%s" % samesite
     header("Set-Cookie", value)
 
 

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -509,7 +509,7 @@ def setcookie(
     if httponly:
         morsel["httponly"] = True
     value = morsel.OutputString()
-    if samesite and samesite.lower() in ["strict", "lax"]:
+    if samesite and samesite.lower() in ("strict", "lax"):
         value += "; SameSite=%s" % samesite
     header("Set-Cookie", value)
 


### PR DESCRIPTION
- Remove py2.3 support
- Replace 'attr in obj.keys()' by 'attr in obj'.
- Set default cookie expire time to session timeout.
- Add support for SameSite cookie.

Fixes #521
Fixes #61 #99 #337
Fixes #409 #410 

TODO:

- Update doc to mention `samesite`: http://webpy.org/cookbook/cookies