### PR TITLE
Fixed incorrect returned insert ids with `multiple_insert()`.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -7,7 +7,7 @@
 * Return body for NoMethod error handler (fixes #240, tx @waldhol)
 * Fixed unicode in request url (fixes #461, tx @schneidersoft)
 * Only store new session data if the data is non-default (fixes #161, tx @shish)
-* Fixes inline comment in Templator which leads to unexpected behavior (fixes
+* Fixed inline comment in Templator which leads to unexpected behavior (fixes
   #432, tx @lucylqe)
 * Allow to get data from PATCH request (fixes #259, tx @kufd)
 * Fixed missing exception (ValueError) for socket.inet_pton to be compatible
@@ -21,6 +21,7 @@
   #140, tx @chuangbo)
 * Supports `SameSite` cookie attribute (fixes #61 #99 #337)
 * Cookie expire time is now set to same as session `timeout` (fixes #409 #410)
+* Fixed incorrect returned row ids with `multiple_insert()` (fixes #263 #447)
 
 ## 2018-02-28 0.39
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -144,7 +144,7 @@ class DBTest(unittest.TestCase):
     def testPooling(self):
         # can't test pooling if DBUtils is not installed
         try:
-            import DBUtils
+            import DBUtils  # noqa
         except ImportError:
             return
         db = setup_database(self.dbname, pooling=True)

--- a/web/db.py
+++ b/web/db.py
@@ -59,6 +59,7 @@ pg_drivers = ["psycopg2", "psycopg", "pgdb"]
 mysql_drivers = ["MySQLdb", "pymysql", "mysql.connector"]
 sqlite_drivers = ["sqlite3", "pysqlite2.dbapi2", "sqlite"]
 
+
 class UnknownDB(Exception):
     """raised for unsupported dbms"""
 
@@ -1002,7 +1003,7 @@ class DB:
             # MySQL gives the first id of multiple inserted rows.
             # PostgreSQL and SQLite give the last id.
             if self.db_module.__name__ in mysql_drivers:
-                out = range(out, out+len(values))
+                out = range(out, out + len(values))
             else:
                 out = range(out - len(values) + 1, out + 1)
         except Exception:


### PR DESCRIPTION
Tested with MariaDB-10.1.29 on Ubuntu 18.04, and PostgreSQL-11.5 on OpenBSD 6.5.
Fixes #447
Fixes #263