### PR TITLE
Fix DiskStore concurrency issue.

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -90,7 +90,7 @@ class DiskStoreTest(unittest.TestCase):
         def set_val():
             store["fail"] = "value"
 
-        for c in xrange(10):
+        for c in range(10):
             m = threading.Thread(target=set_val)
             m.start()
             try:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@ import unittest
 import web
 import tempfile
 import os
+import threading
 
 
 class SessionTest(unittest.TestCase):
@@ -79,6 +80,22 @@ class SessionTest(unittest.TestCase):
         b.open("/redirect")
         b.open("/session/request_token")
         self.assertEqual(b.data, b"123")
+
+class DiskStoreTest(unittest.TestCase):
+    def testStoreConcurrent(self):
+        dir = tempfile.mkdtemp()
+        store = web.session.DiskStore(dir)
+        def set_val():
+            store['fail'] = 'value'
+
+        for c in xrange(10):
+            m = threading.Thread(target=set_val)
+            m.start()
+            try:
+                value = store['fail']
+            except KeyError:
+                pass
+        self.assertEquals(value, 'value')
 
 
 class DBSessionTest(SessionTest):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -81,21 +81,23 @@ class SessionTest(unittest.TestCase):
         b.open("/session/request_token")
         self.assertEqual(b.data, b"123")
 
+
 class DiskStoreTest(unittest.TestCase):
     def testStoreConcurrent(self):
         dir = tempfile.mkdtemp()
         store = web.session.DiskStore(dir)
+
         def set_val():
-            store['fail'] = 'value'
+            store["fail"] = "value"
 
         for c in xrange(10):
             m = threading.Thread(target=set_val)
             m.start()
             try:
-                value = store['fail']
+                value = store["fail"]
             except KeyError:
                 pass
-        self.assertEquals(value, 'value')
+        self.assertEquals(value, "value")
 
 
 class DBSessionTest(SessionTest):

--- a/web/session.py
+++ b/web/session.py
@@ -8,6 +8,7 @@ import os.path
 import time
 import datetime
 import base64
+import threading
 from copy import deepcopy
 
 try:
@@ -287,11 +288,13 @@ class DiskStore(Store):
         path = self._get_path(key)
         pickled = self.encode(value)
         try:
-            f = open(path, "wb")
+            tname = path + "." + threading.current_thread().getname()
+            f = open(tname, "wb")
             try:
                 f.write(pickled)
             finally:
                 f.close()
+                os.rename(tname, path) #atomary operation
         except IOError:
             pass
 

--- a/web/session.py
+++ b/web/session.py
@@ -279,7 +279,8 @@ class DiskStore(Store):
         path = self._get_path(key)
 
         if os.path.exists(path):
-            pickled = open(path, "rb").read()
+            with open(path, "rb") as fh:
+                pickled = fh.read()
             return self.decode(pickled)
         else:
             raise KeyError(key)

--- a/web/session.py
+++ b/web/session.py
@@ -294,7 +294,7 @@ class DiskStore(Store):
                 f.write(pickled)
             finally:
                 f.close()
-                os.rename(tname, path) #atomary operation
+                os.rename(tname, path)  # atomary operation
         except IOError:
             pass
 

--- a/web/session.py
+++ b/web/session.py
@@ -288,7 +288,7 @@ class DiskStore(Store):
         path = self._get_path(key)
         pickled = self.encode(value)
         try:
-            tname = path + "." + threading.current_thread().getname()
+            tname = path + "." + threading.current_thread().getName()
             f = open(tname, "wb")
             try:
                 f.write(pickled)


### PR DESCRIPTION
Write the diskstore in one atomary action
    
This will prevent multiple threads from accessing the file and possibly
read it while it is still being written to.

Fixes #191
Fixes #182 
Fixes #83
Fixes #289

This is in essence the same as my pull request #239 from 2013 with some unittesting.



