### PR TITLE
Remove simplejson in favor of json

### DIFF
--- a/experimental/pwt.py
+++ b/experimental/pwt.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
+import json
 import web
-import simplejson, sudo
+import sudo
 
 # fmt: off
 urls = (
@@ -58,7 +59,7 @@ function receive(d) {
         self._inFunc = False
 
         web.header("Content-Type", "text/javascript")
-        print("receive(" + simplejson.dumps(self.updated) + ");")
+        print("receive(" + json.dumps(self.updated) + ");")
 
     def __setattr__(self, k, v):
         if self._inFunc and k != "_inFunc":

--- a/experimental/untwisted.py
+++ b/experimental/untwisted.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
-import random
+import json
 
-from twisted.internet import reactor, defer
+from twisted.internet import reactor
 from twisted.web import http
-
-import simplejson
 
 import web
 
@@ -104,7 +102,7 @@ class JSFeed(Feed):
         Feed.publish(
             self,
             '<script type="text/javascript">window.parent.%s(%s)</script>'
-            % (self.callback, simplejson.dumps(obj) + " " * 2048),
+            % (self.callback, json.dumps(obj) + " " * 2048),
         )
 
 


### PR DESCRIPTION
Remove an external dependency by replacing it with a module in the Python Standard Library.