### PR TITLE
Added link to travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ web.py is a web framework for Python that is as simple as it is powerful.
 
 Visit http://webpy.org/ for more information.
 
-![build status](https://secure.travis-ci.org/webpy/webpy.png?branch=master)
+[![build status](https://secure.travis-ci.org/webpy/webpy.png?branch=master)](https://travis-ci.org/webpy/webpy)
 [![Codecov Test Coverage](https://codecov.io/gh/webpy/webpy/branch/master/graphs/badge.svg?style=flat)](https://codecov.io/gh/webpy/webpy)
 
 If you want to run web.py on __Python 3__, please install the latest dev


### PR DESCRIPTION
The Travis badge in the README was just an image. Linked it to the Travis CI page for web.py.