### PR TITLE
Fixed the issue of len not working with the result of db query.

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -475,6 +475,100 @@ def sqlquote(a):
         return sqlparam(a).sqlquery()
 
 
+class BaseResultSet:
+    """Base implementation of Result Set, the result of a db query.
+    """
+
+    def __init__(self, cursor):
+        self.cursor = cursor
+        self.names = [x[0] for x in cursor.description]
+        self._index = 0
+
+    def list(self):
+        rows = [self._prepare_row(d) for d in self.cursor.fetchall()]
+        self._index += len(rows)
+        return rows
+
+    def _prepare_row(self, row):
+        return storage(dict(zip(self.names, row)))
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        row = self.cursor.fetchone()
+        if row is None:
+            raise StopIteration()
+        self._index += 1
+        return self._prepare_row(row)
+
+    next = __next__  # for python 2.7 support
+
+    def first(self, default=None):
+        """Returns the first row of this ResultSet or None when there are no
+        elements.
+
+        If the optional argument default is specified, that is returned instead
+        of None when there are no elements.
+        """
+        try:
+            return next(iter(self))
+        except StopIteration:
+            return default
+
+    def __getitem__(self, i):
+        # todo: slices
+        if i < self._index:
+            raise IndexError("already passed " + str(i))
+        try:
+            while i > self._index:
+                next(self)
+                self._index += 1
+            # now self._index == i
+            self._index += 1
+            return next(self)
+        except StopIteration:
+            raise IndexError(str(i))
+
+
+class ResultSet(BaseResultSet):
+    """The result of a database query.
+    """
+
+    def __len__(self):
+        return int(self.cursor.rowcount)
+
+
+class SqliteResultSet(BaseResultSet):
+    """Result Set for sqlite.
+
+    Same functionaly as ResultSet except len is not supported.
+    """
+
+    def __init__(self, cursor):
+        BaseResultSet.__init__(self, cursor)
+        self._head = None
+
+    def __next__(self):
+        if self._head is not None:
+            self._index += 1
+            return self._head
+        else:
+            return super().__next__()
+
+    def __bool__(self):
+        # The ResultSet class class doesn't need to support __bool__ explicity
+        # because it has __len__. Since SqliteResultSet doesn't support len,
+        # we need to peep into the result to find if the result is empty of not.
+        if self._head is None:
+            try:
+                self._head = next(self)
+                self._index -= 1  # reset the index
+            except StopIteration:
+                return False
+        return True
+
+
 class Transaction:
     """Database transaction."""
 
@@ -737,25 +831,16 @@ class DB:
         self._db_execute(db_cursor, sql_query)
 
         if db_cursor.description:
-            names = [x[0] for x in db_cursor.description]
-
-            def iterwrapper():
-                row = db_cursor.fetchone()
-                while row:
-                    yield storage(dict(zip(names, row)))
-                    row = db_cursor.fetchone()
-
-            out = iterbetter(iterwrapper())
-            out.__len__ = lambda: int(db_cursor.rowcount)
-            out.list = lambda: [
-                storage(dict(zip(names, x))) for x in db_cursor.fetchall()
-            ]
+            return self.create_result_set(db_cursor)
         else:
             out = db_cursor.rowcount
 
         if not self.ctx.transactions:
             self.ctx.commit()
         return out
+
+    def create_result_set(self, cursor):
+        return ResultSet(cursor)
 
     def select(
         self,
@@ -1232,11 +1317,8 @@ class SqliteDB(DB):
     def _process_insert_query(self, query, tablename, seqname):
         return query, SQLQuery("SELECT last_insert_rowid();")
 
-    def query(self, *a, **kw):
-        out = DB.query(self, *a, **kw)
-        if isinstance(out, iterbetter):
-            del out.__len__
-        return out
+    def create_result_set(self, cursor):
+        return SqliteResultSet(cursor)
 
 
 class FirebirdDB(DB):


### PR DESCRIPTION
The earlier implentation was adding an __len__ function to the result
object and that worked fine for old-style classes. With old-style
classes gone in Python 3, that started giving trouble. Fixed it by
writing a ResultSet class and a special SqliteResultSet which doesn't
support len, but supports bool.

Fixes #547.