### PR TITLE
Fixed the issue with debugerror.

### DIFF
--- a/web/debugerror.py
+++ b/web/debugerror.py
@@ -35,7 +35,7 @@ else:
 
 whereami = os.path.join(os.getcwd(), __file__)
 whereami = os.path.sep.join(whereami.split(os.path.sep)[:-1])
-djangoerror_t = r"""\
+djangoerror_t = """\
 $def with (exception_type, exception_value, frames)
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">


### PR DESCRIPTION
The debugerror_t was turned into a raw string in an earlier commit [[1]]
and it was using a \ in the first line as line continuation. It became a
literal \ after the string became a raw string. Fixed it by making it
into a regular string.

Fixes #555

[1]: https://github.com/webpy/webpy/commit/6bfd02668e9f56ed49f5146f42046e48263da4c1#diff-8cb9990e42dd192c282402bb2016483dR38