### PR TITLE
Drop from imp import reload for Python3 < 3.4

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -26,7 +26,7 @@ except ImportError:
 
 try:
     reload  # Python 2
-except ImportError:
+except NameError:
     from importlib import reload  # Python 3
 
 from io import BytesIO

--- a/web/application.py
+++ b/web/application.py
@@ -25,7 +25,7 @@ except ImportError:
     from urllib import splitquery, urlencode, unquote
 
 try:
-    reload  # Python
+    reload  # Python 2
 except ImportError:
     from importlib import reload  # Python 3
 

--- a/web/application.py
+++ b/web/application.py
@@ -25,12 +25,9 @@ except ImportError:
     from urllib import splitquery, urlencode, unquote
 
 try:
-    from importlib import reload  # Since Py 3.4 reload is in importlib
+    reload  # Python
 except ImportError:
-    try:
-        from imp import reload  # Since Py 3.0 and before 3.4 reload is in imp
-    except ImportError:
-        pass  # Before Py 3.0 reload is a global function
+    from importlib import reload  # Python 3
 
 from io import BytesIO
 


### PR DESCRIPTION
We do not support Python 3.0, 3.1, 3.2, or 3.3