### PR TITLE
Backward compatibility 'web.utils.utf8' disapear at version 0.40 #568

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -414,6 +414,10 @@ if not PY2:
     safeunicode = safestr
 
 
+# for backward-compatibility
+utf8 = safestr
+
+
 def timelimit(timeout):
     """
     A decorator to limit a function to `timeout` seconds, raising `TimeoutError`


### PR DESCRIPTION
``` 
web.py==0.37
Python 2.7.15+ (default, Jul  9 2019, 16:51:35) 
[GCC 7.4.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from web.utils import utf8 
>>> 
```


```
web.py==0.40
Python 3.7.4 (default, Sep  2 2019, 20:44:09) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from web.utils import utf8
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'utf8' from 'web.utils' (.../python3.7/site-packages/web/utils.py)
>>> 
```

All the web applications that use that function now crash and require updates to use the new version 0.40