### PR TITLE
Travis CI: Upgrade to Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
-
+  - 3.8
 services:
   - mysql
   - postgresql


### PR DESCRIPTION
Web.py seems to have issues with the newest Python release.