### PR TITLE
Fix py3 compatibility issue.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,7 @@
 
 ## 2019-XX-XX 0.50
 
+* Fixed Python-3 compatibility issues: #574, #576.
 * Support tuple and set in `sqlquote()`.
 * Removed function `web.safemarkdown`. if it's used in your application, you
   can install the `Markdown` module from pypi

--- a/web/httpserver.py
+++ b/web/httpserver.py
@@ -236,7 +236,7 @@ class StaticApp(SimpleHTTPRequestHandler):
             if etag == client_etag:
                 self.send_response(304, "Not Modified")
                 self.start_response(self.status, self.headers)
-                raise StopIteration()
+                return
         except OSError:
             pass  # Probably a 404
 

--- a/web/template.py
+++ b/web/template.py
@@ -1293,6 +1293,7 @@ ALLOWED_AST_NODES = [
     "Call",
     "Num",
     "Str",
+    "Joinedstr",
     "Attribute",
     "Subscript",
     "Name",


### PR DESCRIPTION
*) According to [PEP 0479](https://www.python.org/dev/peps/pep-0479/#writing-backwards-and-forwards-compatible-code):

> ... when `StopIteration` is raised inside a generator, it is replaced with `RuntimeError`. ...
>
> ...the change is backwards incompatible...

Close #576

Thanks @kjmph :)

*) Add `Joinedstr` in `ALLOWED_AST_NODES`.

Fixes #578

---------

To @anandology @cclauss 

Do you think we should simply replace `raise StopIteration()` by `return` in other 2 files?

- web/db.py: https://github.com/webpy/webpy/blob/master/web/db.py#L515
- web/webapi.py: https://github.com/webpy/webpy/blob/master/web/webapi.py#L636