### PR TITLE
Extracted Functionality from send() method in utils.py

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -1568,6 +1568,11 @@ class _EmailMessage:
         self.headers = {}
 
     def send(self):
+        try:
+            from . import webapi
+        except ImportError:
+            webapi = Storage(config=Storage())
+
         if webapi.config.get("smtp_server"):
             self.sendWithSMTP()
         elif webapi.config.get("email_engine") == "aws":

--- a/web/utils.py
+++ b/web/utils.py
@@ -1568,22 +1568,22 @@ class _EmailMessage:
         self.headers = {}
 
     def send(self):
+        self.prepare_message()
+        message_text = self.message.as_string()
+
         try:
             from . import webapi
         except ImportError:
             webapi = Storage(config=Storage())
 
         if webapi.config.get("smtp_server"):
-            self.sendWithSMTP()
+            self.send_with_smtp(message_text)
         elif webapi.config.get("email_engine") == "aws":
-            self.sendWithAWS()
+            self.send_with_aws(message_text)
         else:
-            self.defaultEmailSender()
+            self.default_email_sender(message_text)
 
-    def sendWithAWS(self):
-        self.prepare_message()
-        message_text = self.message.as_string()
-
+    def send_with_aws(self, message_text):
         try:
             from . import webapi
         except ImportError:
@@ -1597,10 +1597,7 @@ class _EmailMessage:
         )
         c.send_raw_email(message_text, self.from_address, self.recipients)
 
-    def sendWithSMTP(self):
-        self.prepare_message()
-        message_text = self.message.as_string()
-
+    def send_with_smtp(self, message_text):
         try:
             from . import webapi
         except ImportError:
@@ -1631,10 +1628,7 @@ class _EmailMessage:
         smtpserver.sendmail(self.from_address, self.recipients, message_text)
         smtpserver.quit()
 
-    def defaultEmailSender(self):
-        self.prepare_message()
-        message_text = self.message.as_string()
-
+    def default_email_sender(self, message_text):
         try:
             from . import webapi
         except ImportError:

--- a/web/utils.py
+++ b/web/utils.py
@@ -1583,12 +1583,12 @@ class _EmailMessage:
     def sendWithAWS(self):
         self.prepare_message()
         message_text = self.message.as_string()
-        
+
         try:
             from . import webapi
         except ImportError:
             webapi = Storage(config=Storage())
-        
+
         import boto.ses
 
         c = boto.ses.SESConnection(
@@ -1600,7 +1600,7 @@ class _EmailMessage:
     def sendWithSMTP(self):
         self.prepare_message()
         message_text = self.message.as_string()
-        
+
         try:
             from . import webapi
         except ImportError:
@@ -1634,7 +1634,7 @@ class _EmailMessage:
     def defaultEmailSender(self):
         self.prepare_message()
         message_text = self.message.as_string()
-        
+
         try:
             from . import webapi
         except ImportError:
@@ -1643,6 +1643,7 @@ class _EmailMessage:
         sendmail = webapi.config.get("sendmail_path", "/usr/sbin/sendmail")
 
         assert not self.from_address.startswith("-"), "security"
+
         for r in self.recipients:
             assert not r.startswith("-"), "security"
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -1568,11 +1568,6 @@ class _EmailMessage:
         self.headers = {}
 
     def send(self):
-        try:
-            from . import webapi
-        except ImportError:
-            webapi = Storage(config=Storage())
-
         self.prepare_message()
         message_text = self.message.as_string()
 
@@ -1584,6 +1579,11 @@ class _EmailMessage:
             self.defaultEmailSender()
 
     def sendWithAWS(self):
+        try:
+            from . import webapi
+        except ImportError:
+            webapi = Storage(config=Storage())
+        
         import boto.ses
 
         c = boto.ses.SESConnection(
@@ -1593,6 +1593,11 @@ class _EmailMessage:
         c.send_raw_email(message_text, self.from_address, self.recipients)
 
     def sendWithSMTP(self):
+        try:
+            from . import webapi
+        except ImportError:
+            webapi = Storage(config=Storage())
+
         server = webapi.config.get("smtp_server")
         port = webapi.config.get("smtp_port", 0)
         username = webapi.config.get("smtp_username")
@@ -1619,6 +1624,11 @@ class _EmailMessage:
         smtpserver.quit()
 
     def defaultEmailSender():
+        try:
+            from . import webapi
+        except ImportError:
+            webapi = Storage(config=Storage())
+
         sendmail = webapi.config.get("sendmail_path", "/usr/sbin/sendmail")
 
         assert not self.from_address.startswith("-"), "security"

--- a/web/utils.py
+++ b/web/utils.py
@@ -1568,9 +1568,6 @@ class _EmailMessage:
         self.headers = {}
 
     def send(self):
-        self.prepare_message()
-        message_text = self.message.as_string()
-
         if webapi.config.get("smtp_server"):
             self.sendWithSMTP()
         elif webapi.config.get("email_engine") == "aws":
@@ -1579,6 +1576,9 @@ class _EmailMessage:
             self.defaultEmailSender()
 
     def sendWithAWS(self):
+        self.prepare_message()
+        message_text = self.message.as_string()
+        
         try:
             from . import webapi
         except ImportError:
@@ -1593,6 +1593,9 @@ class _EmailMessage:
         c.send_raw_email(message_text, self.from_address, self.recipients)
 
     def sendWithSMTP(self):
+        self.prepare_message()
+        message_text = self.message.as_string()
+        
         try:
             from . import webapi
         except ImportError:
@@ -1623,7 +1626,10 @@ class _EmailMessage:
         smtpserver.sendmail(self.from_address, self.recipients, message_text)
         smtpserver.quit()
 
-    def defaultEmailSender():
+    def defaultEmailSender(self):
+        self.prepare_message()
+        message_text = self.message.as_string()
+        
         try:
             from . import webapi
         except ImportError:


### PR DESCRIPTION
The send() method in utils.py contained a lot of functionality that could be extracted to their own methods. Including:

- Setting up connections with AWS email server
- Setting up connections with an SMTP server

By extracting this functionality the send() method is reduced from 54 lines to 14, and easier to understand. Plus, if needed in the future, other methods could use the newly created methods to create connections with the email servers and send mail.