### PR TITLE
PEP8: Remove wildcard imports like "from db import *"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
-import sys
+# import os
+# import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -27,6 +27,7 @@ from .utils import *
 from .webapi import *
 from .wsgi import *
 """
+from . import application  # noqa: F401
 
 __version__ = "0.40"
 __author__ = [

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3,6 +3,7 @@
 
 from __future__ import generators
 
+"""
 from . import (
     db,
     debugerror,
@@ -25,6 +26,7 @@ from .net import *
 from .utils import *
 from .webapi import *
 from .wsgi import *
+"""
 
 __version__ = "0.40"
 __author__ = [

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3,6 +3,13 @@
 
 from __future__ import generators
 
+from .application import subdomain_application  # noqa: F401
+from .application import application, auto_application  # noqa: F401
+from .db import database  # noqa: F401
+from .http import changequery  # noqa: F401
+from .utils import storage  # noqa: F401
+from .webapi import HTTPError, ctx, input, seeother, setcookie  # noqa: F401
+
 """
 from . import (
     db,
@@ -27,7 +34,6 @@ from .utils import *
 from .webapi import *
 from .wsgi import *
 """
-from .application import application  # noqa: F401
 
 __version__ = "0.40"
 __author__ = [

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3,8 +3,9 @@
 
 from __future__ import generators
 
-from .application import subdomain_application  # noqa: F401
-from .application import application, auto_application  # noqa: F401
+from . import session
+from .application import application, auto_application, loadhook  # noqa: F401
+from .application import subdomain_application, unloadhook  # noqa: F401
 from .db import database  # noqa: F401
 from .http import changequery  # noqa: F401
 from .utils import storage  # noqa: F401

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,32 +1,7 @@
 #!/usr/bin/env python
 """web.py: makes web apps (http://webpy.org)"""
 
-from __future__ import generators
-
-from . import session  # noqa: F401
-from .application import (  # noqa: F401
-    application,
-    auto_application,
-    loadhook,
-    subdomain_application,
-    unloadhook,
-)
-from .db import database  # noqa: F401
-from .http import changequery  # noqa: F401
-from .utils import storage  # noqa: F401
-from .webapi import (  # noqa: F401
-    HTTPError,
-    cookies,
-    ctx,
-    input,
-    notfound,
-    redirect,
-    seeother,
-    setcookie,
-)
-
-"""
-from . import (
+from . import (  # noqa: F401
     db,
     debugerror,
     form,
@@ -39,16 +14,160 @@ from . import (
     webapi,
     wsgi,
 )
-from .application import *
-from .db import *
-from .debugerror import *
-from .http import *
-from .httpserver import *
-from .net import *
-from .utils import *
-from .webapi import *
+from .application import (  # noqa: F401
+    application,
+    auto_application,
+    autodelegate,
+    loadhook,
+    subdir_application
+    subdomain_application,
+    unloadhook,
+)
+from .db import (  # noqa: F401
+    DB,
+    SQLLiteral,
+    SQLParam,
+    SQLQuery,
+    TransactionError,
+    UnknownDB,
+    UnknownParamstyle,
+    database,
+    reparam,
+    sqllist,
+    sqlliteral,
+    sqlors,
+    sqlparam,
+    sqlquote,
+)
+from debugerror import debugerror, djangoerror, emailerrors  # noqa: F401
+from .http import (  # noqa: F401
+    changequery,
+    expires,
+    lastmodified,
+    modified,
+    prefixurl,
+    profiler,
+    url,
+)
+from .httpserver import runsimple
+from .net import (  # noqa: F401
+    htmlquote,
+    htmlunquote,
+    httpdate,
+    parsehttpdate,
+    urlquote,
+    validaddr,
+    validip,
+    validip6addr,
+    validipaddr,
+    validipport,
+    websafe,
+)
+from .utils import (  # noqa: F401
+    CaptureStdout,
+    Counter,
+    IterBetter,
+    Memoize,
+    Profile,
+    Storage,
+    ThreadedDict,
+    autoassign,
+    capturestdout,
+    commify,
+    cond,
+    counter,
+    dateify,
+    datestr,
+    denumify,
+    dictadd,
+    dictfind,
+    dictfindall,
+    dictincr,
+    dictreverse,
+    group,
+    intget,
+    iterbetter,
+    iters,
+    iterview,
+    listget,
+    lstrips,
+    memoize,
+    nthstr,
+    numify,
+    profile,
+    re_compile,
+    re_subm,
+    requeue,
+    restack,
+    rstrips,
+    safeiter,
+    safestr,
+    safeunicode,
+    safewrite,
+    sendmail,
+    storage,
+    storify,
+    strips,
+    threadeddict,
+    timelimit,
+    to36,
+    tryall,
+    uniq,
+)
+from .webapi import (  # noqa: F401
+    Accepted,
+    BadRequest,
+    Conflict,
+    Created,
+    Forbidden,
+    Found,
+    Gone,
+    HTTPError,
+    InternalError,
+    NoContent,
+    NoMethod,
+    NotAcceptable,
+    NotFound,
+    NotModified,
+    OK,
+    PreconditionFailed,
+    Redirect,
+    SeeOther,
+    TempRedirect,
+    Unauthorized,
+    UnavailableForLegalReasons,
+    UnsupportedMediaType,
+    accepted,
+    badrequest,
+    config,
+    conflict,
+    cookies,
+    created,
+    ctx,
+    data,
+    debug,
+    forbidden,
+    found,
+    gone,
+    header,
+    input,
+    internalerror,
+    nocontent,
+    nomethod,
+    notacceptable,
+    notfound,
+    notmodified,
+    ok,
+    preconditionfailed,
+    redirect,
+    seeother,
+    setcookie,
+    tempredirect,
+    unauthorized,
+    unavailableforlegalreasons,
+    unsupportedmediatype,
+)
 from .wsgi import *
-"""
 
 __version__ = "0.40"
 __author__ = [

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -19,7 +19,7 @@ from .application import (  # noqa: F401
     auto_application,
     autodelegate,
     loadhook,
-    subdir_application
+    subdir_application,
     subdomain_application,
     unloadhook,
 )
@@ -39,7 +39,7 @@ from .db import (  # noqa: F401
     sqlparam,
     sqlquote,
 )
-from debugerror import debugerror, djangoerror, emailerrors  # noqa: F401
+from .debugerror import debugerror, djangoerror, emailerrors  # noqa: F401,F811
 from .http import (  # noqa: F401
     changequery,
     expires,
@@ -49,7 +49,7 @@ from .http import (  # noqa: F401
     profiler,
     url,
 )
-from .httpserver import runsimple
+from .httpserver import runsimple  # noqa: F401
 from .net import (  # noqa: F401
     htmlquote,
     htmlunquote,
@@ -167,7 +167,7 @@ from .webapi import (  # noqa: F401
     unavailableforlegalreasons,
     unsupportedmediatype,
 )
-from .wsgi import *
+from .wsgi import *  # noqa: F401,F403
 
 __version__ = "0.40"
 __author__ = [

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4,13 +4,26 @@
 from __future__ import generators
 
 from . import session  # noqa: F401
-from .application import (application, auto_application, loadhook,  # noqa: F401
-                          subdomain_application, unloadhook)
+from .application import (  # noqa: F401
+    application,
+    auto_application,
+    loadhook,
+    subdomain_application,
+    unloadhook,
+)
 from .db import database  # noqa: F401
 from .http import changequery  # noqa: F401
 from .utils import storage  # noqa: F401
-from .webapi import (HTTPError, cookies, ctx, input, notfound, redirect,  # noqa: F401
-                     seeother, setcookie)
+from .webapi import (  # noqa: F401
+    HTTPError,
+    cookies,
+    ctx,
+    input,
+    notfound,
+    redirect,
+    seeother,
+    setcookie,
+)
 
 """
 from . import (

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3,13 +3,14 @@
 
 from __future__ import generators
 
-from . import session
-from .application import application, auto_application, loadhook  # noqa: F401
-from .application import subdomain_application, unloadhook  # noqa: F401
+from . import session  # noqa: F401
+from .application import (application, auto_application, loadhook,  # noqa: F401
+                          subdomain_application, unloadhook)
 from .db import database  # noqa: F401
 from .http import changequery  # noqa: F401
 from .utils import storage  # noqa: F401
-from .webapi import HTTPError, ctx, input, seeother, setcookie  # noqa: F401
+from .webapi import (HTTPError, cookies, ctx, input, notfound, redirect,  # noqa: F401
+                     seeother, setcookie)
 
 """
 from . import (

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -27,7 +27,7 @@ from .utils import *
 from .webapi import *
 from .wsgi import *
 """
-from . import application  # noqa: F401
+from .application import application  # noqa: F401
 
 __version__ = "0.40"
 __author__ = [

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -17,7 +17,7 @@ class render_cheetah:
 
     def __init__(self, path):
         # give error if Chetah is not installed
-        from Cheetah.Template import Template
+        from Cheetah.Template import Template  # noqa: F401
 
         self.path = path
 

--- a/web/template.py
+++ b/web/template.py
@@ -1178,7 +1178,7 @@ class GAE_Render(Render):
 render = Render
 # setup render for Google App Engine.
 try:
-    from google import appengine
+    from google import appengine  # noqa: F401
 
     render = Render = GAE_Render
 except ImportError:

--- a/web/utils.py
+++ b/web/utils.py
@@ -15,15 +15,8 @@ import time
 import traceback
 from threading import local as threadlocal
 
-from .py3helpers import (
-    PY2,
-    imap,
-    is_iter,
-    iteritems,
-    itervalues,
-    string_types,
-    text_type,
-)
+from .py3helpers import (PY2, imap, is_iter, iteritems, itervalues,
+                         string_types, text_type)
 
 try:
     from StringIO import StringIO

--- a/web/utils.py
+++ b/web/utils.py
@@ -15,8 +15,15 @@ import time
 import traceback
 from threading import local as threadlocal
 
-from .py3helpers import (PY2, imap, is_iter, iteritems, itervalues,
-                         string_types, text_type)
+from .py3helpers import (
+    PY2,
+    imap,
+    is_iter,
+    iteritems,
+    itervalues,
+    string_types,
+    text_type,
+)
 
 try:
     from StringIO import StringIO

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 from io import BytesIO
 
-from .py3helpers import PY2, text_type, urljoin
+from .py3helpers import text_type, urljoin
 from .utils import dictadd, intget, safestr, storage, storify, threadeddict
 
 try:


### PR DESCRIPTION
Fixes: #604   This needs careful review because it might have put enough imports in place to pass the tests but other apps might be looking for other imports.