### PR TITLE
Drop support for SQL drivers: pgdb, psycopg.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -8,6 +8,10 @@
 * Fixed: not support `samesite=none`. #592
 * Fixed Python-3 compatibility issues: #574, #576.
 * Support tuple and set in `sqlquote()`.
+* Drop support for SQL driver `pgdb`. It was dead, you cannot even find its
+  website or download link.
+* Drop support for SQL driver `psycopg`. The latest version was released in
+  2006 (14 years ago), please use `psycopg2` instead.
 * Removed function `web.safemarkdown`. if it's used in your application, you
   can install the `Markdown` module from pypi
   (https://pypi.org/project/Markdown/), then replace `web.safemarkdown()` by

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,6 +9,4 @@ PyMySQL>=0.9.3
 mysql-connector-python>=8.0.19
 
 # pgsql
-#psycopg; python_version == '2.7'
 psycopg2>=2.8.4
-#pgdb>=0.0.8

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -257,16 +257,6 @@ class PostgresTest2(DBTest):
         assert len(db.select("person").list()) == 1
 
 
-@requires_module("psycopg")
-class PostgresTest_psycopg(PostgresTest2):
-    driver = "psycopg"
-
-
-@requires_module("pgdb")
-class PostgresTest_pgdb(PostgresTest2):
-    driver = "pgdb"
-
-
 @requires_module("sqlite3")
 class SqliteTest(DBTest):
     dbname = "sqlite"

--- a/web/db.py
+++ b/web/db.py
@@ -55,7 +55,7 @@ TOKEN = "[ \\f\\t]*(\\\\\\r?\\n[ \\f\\t]*)*(#[^\\r\\n]*)?(((\\d+[jJ]|((\\d+\\.\\
 tokenprog = re.compile(TOKEN)
 
 # Supported db drivers.
-pg_drivers = ["psycopg2", "psycopg", "pgdb"]
+pg_drivers = ["psycopg2"]
 mysql_drivers = ["MySQLdb", "pymysql", "mysql.connector"]
 sqlite_drivers = ["sqlite3", "pysqlite2.dbapi2", "sqlite"]
 
@@ -1205,8 +1205,6 @@ class PostgresDB(DB):
             import psycopg2.extensions
 
             psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
-        if db_module.__name__ == "pgdb" and "port" in keywords:
-            keywords["host"] += ":" + str(keywords.pop("port"))
 
         # if db is not provided `postgres` driver will take it from PGDATABASE
         # environment variable.
@@ -1240,20 +1238,12 @@ class PostgresDB(DB):
 
     def _connect(self, keywords):
         conn = DB._connect(self, keywords)
-        try:
-            conn.set_client_encoding("UTF8")
-        except AttributeError:
-            # fallback for pgdb driver
-            conn.cursor().execute("set client_encoding to 'UTF-8'")
+        conn.set_client_encoding("UTF8")
         return conn
 
     def _connect_with_pooling(self, keywords):
         conn = DB._connect_with_pooling(self, keywords)
-        try:
-            conn._con._con.set_client_encoding("UTF8")
-        except AttributeError:
-            # fallback for pgdb driver
-            conn.cursor().execute("set client_encoding to 'UTF-8'")
+        conn._con._con.set_client_encoding("UTF8")
         return conn
 
 
@@ -1283,7 +1273,7 @@ class MySQLDB(DB):
         elif keywords["charset"] is None:
             del keywords["charset"]
 
-        self.paramstyle = db.paramstyle = "pyformat"  # it's both, like psycopg
+        self.paramstyle = db.paramstyle = "pyformat"  # it's both
         self.dbname = "mysql"
         DB.__init__(self, db, keywords)
         self.supports_multiple_insert = True


### PR DESCRIPTION
As mentioned in updated ChangeLog.txt:

- Drop support for SQL driver `pgdb`. It was dead, it's mysterious that you cannot even find its website or download link. Note: The one available on [pypi](https://pypi.org/project/pgdb/) is not same as the one used in web.py. 
- Drop support for SQL driver `psycopg`. The latest version was released in 2006 (14 years ago), i doubt anyone still using `psycopg` but not `psycopg2`. Please use `psycopg2` instead.