### PR TITLE
Fix github action failure: use mysql docker instead of the builtin mysql service

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Generate /tmp/my.cnf"
         run: echo -e "[client]\nhost=127.0.0.1\nport=3306\nuser=root\npassword='root'" > /tmp/my.cnf
       - name: "Create MySQL user and database used for testing."
-        run: mysql --defaults-file=/tmp/my.cnf -e "create user 'scott'@'localhost' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'localhost' with grant option;"
+        run: mysql --defaults-file=/tmp/my.cnf -e "create user 'scott'@'127.0.0.1' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'127.0.0.1' with grant option;"
 
       - name: "Create PostgreSQL user and database."
         run: |

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Use the default MySQL server offered by Github Actions.
       - name: "Generate /tmp/my.cnf"
-        run: echo -e "[client]\nuser=root\npassword='root'" > /tmp/my.cnf
+        run: echo -e "[client]\nhost=127.0.0.1\nport=3306\nuser=root\npassword='root'" > /tmp/my.cnf
       - name: "Create MySQL user and database used for testing."
         run: mysql --defaults-file=/tmp/my.cnf -e "create user 'scott'@'localhost' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'localhost' with grant option;"
 

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       mariadb:
         image: mariadb:10.4
         ports:
-          - 3306
+          - 3306:3306
         env:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
@@ -49,6 +49,9 @@ jobs:
 
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt
+
+      - name: "Testing: check which network services are running."
+        run: netstat -ntlp
 
       # Use the default MySQL server offered by Github Actions.
       - name: "Generate /tmp/my.cnf"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,8 +10,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.4
-        cmd: "--bind-address=0.0.0.0"
+        image: mysql:5.7
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,6 +11,7 @@ jobs:
     services:
       mariadb:
         image: mariadb:10.4
+        cmd: "--bind-address=0.0.0.0"
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,6 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      mariadb:
+        image: mariadb:10.4
+        ports:
+          - 3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
       postgres:
         image: postgres:latest
         env:
@@ -29,6 +37,7 @@ jobs:
       - uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python-version }}
+
       - run: pip install codespell flake8 isort pytest
       - if: matrix.python-version >= 3.6
         run: |
@@ -37,7 +46,9 @@ jobs:
       - run: codespell . --ignore-words-list=eith,gae --skip=./.* --quiet-level=2
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --recursive .
-      - run: pip install -r requirements.txt -r test_requirements.txt
+
+      - name: "Install dependent Python modules for testing."
+        run: pip install -r requirements.txt -r test_requirements.txt
 
       # Use the default MySQL server offered by Github Actions.
       - name: "Generate /tmp/my.cnf"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -40,9 +40,13 @@ jobs:
       - run: pip install -r requirements.txt -r test_requirements.txt
 
       # Use the default MySQL server offered by Github Actions.
-      - run: mysql -uroot -proot -e "create user 'scott'@'localhost' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'localhost' with grant option;"
+      - name: "Generate /tmp/my.cnf"
+        run: echo -e "[client]\nuser=root\npassword='root'" > /tmp/my.cnf
+      - name: "Create MySQL user and database used for testing."
+        run: mysql --defaults-file=/tmp/my.cnf -e "create user 'scott'@'localhost' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'localhost' with grant option;"
 
-      - run: |
+      - name: "Create PostgreSQL user and database."
+        run: |
           createdb -h localhost -U postgres webpy
           createuser -h localhost -U postgres -d scott
           psql -h localhost -U postgres -d postgres -c "ALTER USER scott WITH ENCRYPTED PASSWORD 'tiger'"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Generate /tmp/my.cnf"
         run: echo -e "[client]\nhost=127.0.0.1\nport=3306\nuser=root\npassword='root'" > /tmp/my.cnf
       - name: "Create MySQL user and database used for testing."
-        run: mysql --defaults-file=/tmp/my.cnf -e "create user 'scott'@'127.0.0.1' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'127.0.0.1' with grant option;"
+        run: mysql --defaults-file=/tmp/my.cnf -e "create user 'scott'@'%' identified by 'tiger'; create database webpy; grant all privileges on webpy.* to 'scott'@'%' with grant option;"
 
       - name: "Create PostgreSQL user and database."
         run: |

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -72,7 +72,8 @@ jobs:
       # Env variables `WEBPY_DB_` are required for sql db connections.
       - run: pytest --capture=no --exitfirst --verbose .
         env:
-          WEBPY_DB_HOST: localhost
+          WEBPY_DB_HOST: 127.0.0.1
+          WEBPY_DB_MYSQL_PORT: 3306
           WEBPY_DB_PG_PORT: 5432
           WEBPY_DB_NAME: webpy
           WEBPY_DB_USER: scott

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -50,9 +50,6 @@ jobs:
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt
 
-      - name: "Testing: check which network services are running."
-        run: netstat -ntlp
-
       # Use the default MySQL server offered by Github Actions.
       - name: "Generate /tmp/my.cnf"
         run: echo -e "[client]\nhost=127.0.0.1\nport=3306\nuser=root\npassword='root'" > /tmp/my.cnf

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -51,7 +51,7 @@ def setup_database(dbname, driver=None, pooling=False):
         db = web.database(
             dbn=dbname,
             host=os.getenv("WEBPY_DB_HOST", "localhost"),
-            port=os.getenv("WEBPY_DB_PG_PORT", 5432),
+            port=int(os.getenv("WEBPY_DB_PG_PORT", 5432)),
             db=os.getenv("WEBPY_DB_NAME", "webpy"),
             user=os.getenv("WEBPY_DB_USER", os.getenv("USER")),
             pw=os.getenv("WEBPY_DB_PASSWORD", ""),
@@ -62,7 +62,7 @@ def setup_database(dbname, driver=None, pooling=False):
         db = web.database(
             dbn=dbname,
             host=os.getenv("WEBPY_DB_HOST", "localhost"),
-            port=os.getenv("WEBPY_DB_MYSQL_PORT", 3306),
+            port=int(os.getenv("WEBPY_DB_MYSQL_PORT", 3306)),
             db=os.getenv("WEBPY_DB_NAME", "webpy"),
             user=os.getenv("WEBPY_DB_USER", os.getenv("USER")),
             pw=os.getenv("WEBPY_DB_PASSWORD", ""),

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -61,9 +61,11 @@ def setup_database(dbname, driver=None, pooling=False):
     else:
         db = web.database(
             dbn=dbname,
-            db="webpy",
-            user="scott",
-            pw="tiger",
+            host=os.getenv("WEBPY_DB_HOST", "localhost"),
+            port=os.getenv("WEBPY_DB_MYSQL_PORT", 3306),
+            db=os.getenv("WEBPY_DB_NAME", "webpy"),
+            user=os.getenv("WEBPY_DB_USER", os.getenv("USER")),
+            pw=os.getenv("WEBPY_DB_PASSWORD", ""),
             pooling=pooling,
             driver=driver,
         )


### PR DESCRIPTION
- Seems GitHub Actions dropped the builtin mysql service, i have to use docker image to run mysql service for testing.
- Modified `tests/test_db.py` to read MySQL host/port/db/user/pw from env variables (if not given, use pre-defined values).

Sorry for the noise of a lot GitHub Actions failures.