### PR TITLE
Drop py2: 

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # TODO: (cclauss) add pypy3  https://github.com/webpy/webpy/issues/598
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]  # , pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8]  # , pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7
@@ -28,9 +27,6 @@ before_script:
 
 script:
   - pytest --cov --cov-report=term-missing --cov-report=xml
-  - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ]; then
-      pytest --doctest-modules ./web --cov-report=xml ;
-    fi
 
 after_success:
   - |

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,10 @@
 # web.py changelog
 
+## 2020-XX-YY 1.0
+
+* Python-2 support has been completely dropped. Welcome to Python-3.
+* Remove support for MySQL driver `MySQLdb`, it doesn't work with py3 at all.
+
 ## 2020-03-20 0.50
 
 * New session store `MemoryStore`, used to save a session in memory.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,7 +2,7 @@
 
 ## 2020-XX-YY 1.0
 
-* Python-2 support has been completely dropped. Welcome to Python-3.
+* Python-2 support has been completely dropped. Welcome to Python 3.
 * Remove support for MySQL driver `MySQLdb`, it doesn't work with py3 at all.
 
 Supported SQL drivers:

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,11 @@
 * Python-2 support has been completely dropped. Welcome to Python-3.
 * Remove support for MySQL driver `MySQLdb`, it doesn't work with py3 at all.
 
+Supported SQL drivers:
+
+- MySQL: pymysql, mysql.connector.
+- PostgreSQL: psycopg2.
+
 ## 2020-03-20 0.50
 
 * New session store `MemoryStore`, used to save a session in memory.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,6 @@ pytest>=4.6.2
 
 # DB drivers.
 # mysql
-MySQL-python>=1.2.5; python_version == '2.7'
 PyMySQL>=0.9.3
 mysql-connector-python>=8.0.19
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 cheroot>=6.0.0
 DBUtils
-pytest>=4.6.2
+pytest>=5.4.1
 
 # DB drivers.
 # mysql

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,11 +7,6 @@ import unittest
 
 import web
 
-try:
-    unicode  # Python 2
-except NameError:
-    unicode = str  # Python 3
-
 
 def try_import(name):
     try:
@@ -196,12 +191,6 @@ class DBTest(unittest.TestCase):
             ids = db.multiple_insert("mi", values)
             assert list(ids) == [4, 5, 6]
 
-    def test_result_is_unicode(self):
-        # TODO : not sure this test has still meaning with Py3
-        self.db.insert("person", False, name="user")
-        name = self.db.select("person")[0].name
-        self.assertEqual(type(name), unicode)
-
     def test_result_is_true(self):
         self.db.insert("person", False, name="user")
         self.assertEqual(bool(self.db.select("person")), True)
@@ -284,7 +273,7 @@ class MySQLTest_PYMYSQL(DBTest):
     driver = "pymysql"
 
     def setUp(self):
-        self.db = setup_database(self.dbname)
+        self.db = setup_database(self.dbname, driver=self.driver)
         # In mysql, transactions are supported only with INNODB engine.
         self.db.query("CREATE TABLE person (name text, email text) ENGINE=INNODB")
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -278,10 +278,10 @@ class SqliteTest_pysqlite2(SqliteTest):
     driver = "pysqlite2.dbapi2"
 
 
-@requires_module("MySQLdb")
-class MySQLTest_MySQLdb(DBTest):
+@requires_module("pymysql")
+class MySQLTest_PYMYSQL(DBTest):
     dbname = "mysql"
-    driver = "MySQLdb"
+    driver = "pymysql"
 
     def setUp(self):
         self.db = setup_database(self.dbname)
@@ -293,13 +293,8 @@ class MySQLTest_MySQLdb(DBTest):
         pass
 
 
-@requires_module("pymysql")
-class MySQLTest_PyMySQL(MySQLTest_MySQLdb):
-    driver = "pymysql"
-
-
 @requires_module("mysql.connector")
-class MySQLTest_MySQLConnector(MySQLTest_MySQLdb):
+class MySQLTest_MySQLConnector(MySQLTest_PYMYSQL):
     driver = "mysql.connector"
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,13 +1,7 @@
 import unittest
 
 import web
-from web.py3helpers import PY2
 from web.template import SecurityError, Template
-
-try:
-    unicode  # Python 2
-except NameError:
-    unicode = str  # Python 3
 
 
 class _TestResult:
@@ -18,7 +12,7 @@ class _TestResult:
         return getattr(self.t, name)
 
     def __repr__(self):
-        return repr(unicode(self.t))
+        return repr(str(self.t))
 
 
 def t(code, **keywords):
@@ -30,18 +24,8 @@ class TemplateTest(unittest.TestCase):
     """Tests for the template security feature."""
 
     def testPrint(self):
-        if PY2:
-            tpl = "$code:\n    print 'blah'"
-            # print_function has been imported from __future__ so the print statement doesn't exist anymore
-            self.assertRaises(SyntaxError, t, tpl)
-        else:
-            tpl = "$code:\n    print('blah')"
-            self.assertRaises(NameError, t(tpl))
-
-    def testRepr(self):
-        if PY2:  # this feature doesn't exist in Py3 anymore
-            tpl = "$code:\n    `1`"
-            self.assertRaises(SecurityError, t, tpl)
+        tpl = "$code:\n    print('blah')"
+        self.assertRaises(NameError, t(tpl))
 
     def testAttr(self):
         tpl = "$code:\n    (lambda x: x+1).func_code"
@@ -52,8 +36,7 @@ class TemplateTest(unittest.TestCase):
 
         # these two should execute themselves flawlessly
         t("$code:\n    foo = {'a': 1}.items()")()
-        if not PY2:
-            t("$code:\n    bar = {k:0 for k in [1,2,3]}")()
+        t("$code:\n    bar = {k:0 for k in [1,2,3]}")()
 
 
 class TestRender:

--- a/web/application.py
+++ b/web/application.py
@@ -332,8 +332,6 @@ class application:
                 for r in result:
                     if isinstance(r, bytes):
                         yield r
-                    elif isinstance(r, str):
-                        yield r.encode("utf-8")
                     else:
                         yield str(r).encode("utf-8")
 

--- a/web/application.py
+++ b/web/application.py
@@ -16,7 +16,7 @@ from . import browser, httpserver, utils
 from . import webapi as web
 from . import wsgi
 from .debugerror import debugerror
-from .py3helpers import is_iter, iteritems, string_types
+from .py3helpers import is_iter, iteritems
 from .utils import lstrips
 
 from urllib.parse import urlparse, urlencode, unquote
@@ -332,7 +332,7 @@ class application:
                 for r in result:
                     if isinstance(r, bytes):
                         yield r
-                    elif isinstance(r, string_types):
+                    elif isinstance(r, str):
                         yield r.encode("utf-8")
                     else:
                         yield str(r).encode("utf-8")
@@ -503,7 +503,7 @@ class application:
             return f.handle_with_processors()
         elif isclass(f):
             return handle_class(f)
-        elif isinstance(f, string_types):
+        elif isinstance(f, str):
             if f.startswith("redirect "):
                 url = f.split(" ", 1)[1]
                 if web.ctx.method == "GET":
@@ -531,7 +531,7 @@ class application:
                     return f, None
                 else:
                     continue
-            elif isinstance(what, string_types):
+            elif isinstance(what, str):
                 what, result = utils.re_subm(r"^%s\Z" % (pat,), what, value)
             else:
                 result = utils.re_compile(r"^%s\Z" % (pat,)).match(value)
@@ -664,7 +664,7 @@ class subdomain_application(application):
 
     def _match(self, mapping, value):
         for pat, what in mapping:
-            if isinstance(what, string_types):
+            if isinstance(what, str):
                 what, result = utils.re_subm("^" + pat + "$", what, value)
             else:
                 result = utils.re_compile("^" + pat + "$").match(value)

--- a/web/browser.py
+++ b/web/browser.py
@@ -108,11 +108,7 @@ class Browser(object):
         """Returns content of e or the current document as plain text."""
         e = e or self.get_soup()
         return "".join(
-            [
-                htmlunquote(c)
-                for c in e.recursiveChildGenerator()
-                if isinstance(c, str)
-            ]
+            [htmlunquote(c) for c in e.recursiveChildGenerator() if isinstance(c, str)]
         )
 
     def _get_links(self):

--- a/web/browser.py
+++ b/web/browser.py
@@ -6,36 +6,19 @@ import webbrowser
 from io import BytesIO
 
 from .net import htmlunquote
-from .py3helpers import PY2, text_type
+from .py3helpers import text_type
 from .utils import re_compile
 
-try:  # Py3
-    from http.client import HTTPMessage
-    from urllib.request import HTTPHandler, HTTPCookieProcessor, Request, HTTPError
-    from urllib.request import build_opener as urllib_build_opener
-    from urllib.parse import urljoin
-    from http.cookiejar import CookieJar
-    from urllib.response import addinfourl
-except ImportError:  # Py2
-    from httplib import HTTPMessage
-    from urllib import addinfourl
-    from urllib2 import HTTPHandler, HTTPCookieProcessor, Request, HTTPError
-    from urllib2 import build_opener as urllib_build_opener
-    from cookielib import CookieJar
-    from urlparse import urljoin
+from urllib.request import HTTPHandler, HTTPCookieProcessor, Request, HTTPError
+from urllib.request import build_opener as urllib_build_opener
+from urllib.parse import urljoin
+from http.cookiejar import CookieJar
+from urllib.response import addinfourl
 
-# Welcome to the Py2->Py3 httplib/urllib reorganization nightmare.
-
-if PY2:
-    get_selector = lambda x: x.get_selector()
-    get_host = lambda x: x.get_host()
-    get_data = lambda x: x.get_data()
-    get_type = lambda x: x.get_type()
-else:
-    get_selector = lambda x: x.selector
-    get_host = lambda x: x.host
-    get_data = lambda x: x.data
-    get_type = lambda x: x.type
+get_selector = lambda x: x.selector
+get_host = lambda x: x.host
+get_data = lambda x: x.data
+get_type = lambda x: x.type
 
 DEBUG = False
 
@@ -313,12 +296,9 @@ class AppHandler(HTTPHandler):
 
         data = "\r\n".join(["%s: %s" % (k, v) for k, v in result.header_items])
 
-        if PY2:
-            headers = HTTPMessage(BytesIO(data))
-        else:
-            import email
+        import email
 
-            headers = email.message_from_string(data)
+        headers = email.message_from_string(data)
 
         response = addinfourl(BytesIO(result.data), headers, url)
         code, msg = result.status.split(None, 1)

--- a/web/browser.py
+++ b/web/browser.py
@@ -6,7 +6,6 @@ import webbrowser
 from io import BytesIO
 
 from .net import htmlunquote
-from .py3helpers import text_type
 from .utils import re_compile
 
 from urllib.request import HTTPHandler, HTTPCookieProcessor, Request, HTTPError
@@ -112,7 +111,7 @@ class Browser(object):
             [
                 htmlunquote(c)
                 for c in e.recursiveChildGenerator()
-                if isinstance(c, text_type)
+                if isinstance(c, str)
             ]
         )
 

--- a/web/db.py
+++ b/web/db.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 
-from .py3helpers import iteritems, numeric_types
+from .py3helpers import iteritems
 from .utils import iters, safestr, safeunicode, storage, threadeddict
 
 try:
@@ -396,7 +396,7 @@ def sqlify(obj):
         return "'t'"
     elif obj is False:
         return "'f'"
-    elif isinstance(obj, numeric_types):
+    elif isinstance(obj, int):
         return str(obj)
     elif isinstance(obj, datetime.datetime):
         return repr(obj.isoformat())
@@ -792,7 +792,7 @@ class DB:
         return query, params
 
     def _where(self, where, vars):
-        if isinstance(where, numeric_types):
+        if isinstance(where, int):
             where = "id = " + sqlparam(where)
         # @@@ for backward-compatibility
         elif isinstance(where, (list, tuple)) and len(where) == 2:
@@ -943,7 +943,7 @@ class DB:
         )
 
     def gen_clause(self, sql, val, vars):
-        if isinstance(val, numeric_types):
+        if isinstance(val, int):
             if sql == "WHERE":
                 nout = "id = " + sqlquote(val)
             else:

--- a/web/db.py
+++ b/web/db.py
@@ -56,7 +56,7 @@ tokenprog = re.compile(TOKEN)
 
 # Supported db drivers.
 pg_drivers = ["psycopg2"]
-mysql_drivers = ["MySQLdb", "pymysql", "mysql.connector"]
+mysql_drivers = ["pymysql", "mysql.connector"]
 sqlite_drivers = ["sqlite3", "pysqlite2.dbapi2", "sqlite"]
 
 
@@ -1249,14 +1249,11 @@ class MySQLDB(DB):
 
         db = import_driver(mysql_drivers, preferred=keywords.pop("driver", None))
 
-        if db.__name__ == "MySQLdb":
-            if "pw" in keywords:
-                keywords["passwd"] = keywords["pw"]
-                del keywords["pw"]
         if db.__name__ == "pymysql":
             if "pw" in keywords:
                 keywords["password"] = keywords["pw"]
                 del keywords["pw"]
+
         if db.__name__ == "mysql.connector":
             # Enabled buffered so that len can work as expected.
             keywords.setdefault("buffered", True)
@@ -1502,7 +1499,6 @@ def register_database(name, clazz):
     _databases[name] = clazz
 
 
-register_database("mysql", MySQLDB)
 register_database("postgres", PostgresDB)
 register_database("sqlite", SqliteDB)
 register_database("firebird", FirebirdDB)

--- a/web/db.py
+++ b/web/db.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 
-from .py3helpers import PY2, iteritems, numeric_types, string_types, text_type
+from .py3helpers import iteritems, numeric_types, string_types
 from .utils import iters, safestr, safeunicode, storage, threadeddict
 
 try:
@@ -401,9 +401,6 @@ def sqlify(obj):
     elif isinstance(obj, datetime.datetime):
         return repr(obj.isoformat())
     else:
-        if PY2 and isinstance(obj, text_type):  # Strings are always UTF8 in Py3
-            obj = obj.encode("utf8")
-
         return repr(obj)
 
 

--- a/web/db.py
+++ b/web/db.py
@@ -1499,6 +1499,7 @@ def register_database(name, clazz):
     _databases[name] = clazz
 
 
+register_database("mysql", MySQLDB)
 register_database("postgres", PostgresDB)
 register_database("sqlite", SqliteDB)
 register_database("firebird", FirebirdDB)

--- a/web/db.py
+++ b/web/db.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 
-from .py3helpers import iteritems, numeric_types, string_types
+from .py3helpers import iteritems, numeric_types
 from .utils import iters, safestr, safeunicode, storage, threadeddict
 
 try:
@@ -185,7 +185,7 @@ class SQLQuery(object):
         self.items.append(value)
 
     def __add__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             items = [other]
         elif isinstance(other, SQLQuery):
             items = other.items
@@ -194,7 +194,7 @@ class SQLQuery(object):
         return SQLQuery(self.items + items)
 
     def __radd__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             items = [other]
         elif isinstance(other, SQLQuery):
             items = other.items
@@ -203,7 +203,7 @@ class SQLQuery(object):
         return SQLQuery(items + self.items)
 
     def __iadd__(self, other):
-        if isinstance(other, (string_types, SQLParam)):
+        if isinstance(other, (str, SQLParam)):
             self.items.append(other)
         elif isinstance(other, SQLQuery):
             self.items.extend(other.items)
@@ -413,7 +413,7 @@ def sqllist(lst):
         >>> sqllist('a')
         'a'
     """
-    if isinstance(lst, string_types):
+    if isinstance(lst, str):
         return lst
     else:
         return ", ".join(lst)

--- a/web/debugerror.py
+++ b/web/debugerror.py
@@ -18,20 +18,11 @@ import traceback
 
 from . import webapi as web
 from .net import websafe
-from .py3helpers import PY2
 from .template import Template
 from .utils import safestr, sendmail
 
-if PY2:
-
-    def update_globals_template(t, globals):
-        t.t.func_globals.update(globals)
-
-
-else:
-
-    def update_globals_template(t, globals):
-        t.t.__globals__.update(globals)
+def update_globals_template(t, globals):
+    t.t.__globals__.update(globals)
 
 
 whereami = os.path.join(os.getcwd(), __file__)

--- a/web/debugerror.py
+++ b/web/debugerror.py
@@ -21,6 +21,7 @@ from .net import websafe
 from .template import Template
 from .utils import safestr, sendmail
 
+
 def update_globals_template(t, globals):
     t.t.__globals__.update(globals)
 

--- a/web/http.py
+++ b/web/http.py
@@ -17,7 +17,7 @@ import datetime
 
 from . import net, utils
 from . import webapi as web
-from .py3helpers import iteritems, numeric_types
+from .py3helpers import iteritems
 
 try:
     from urllib.parse import urlencode as urllib_urlencode
@@ -48,7 +48,7 @@ def expires(delta):
     Outputs an `Expires` header for `delta` from now.
     `delta` is a `timedelta` object or a number of seconds.
     """
-    if isinstance(delta, numeric_types):
+    if isinstance(delta, int):
         delta = datetime.timedelta(seconds=delta)
     date_obj = datetime.datetime.utcnow() + delta
     web.header("Expires", net.httpdate(date_obj))

--- a/web/net.py
+++ b/web/net.py
@@ -9,8 +9,6 @@ import re
 import socket
 import time
 
-from .py3helpers import PY2, text_type
-
 try:
     from urllib.parse import quote
 except ImportError:
@@ -194,13 +192,7 @@ def urlquote(val):
     if val is None:
         return ""
 
-    if PY2:
-        if isinstance(val, text_type):
-            val = val.encode("utf-8")
-        else:
-            val = str(val)
-    else:
-        val = str(val).encode("utf-8")
+    val = str(val).encode("utf-8")
     return quote(val)
 
 
@@ -273,16 +265,10 @@ def websafe(val):
     if val is None:
         return u""
 
-    if PY2:
-        if isinstance(val, str):
-            val = val.decode("utf-8")
-        elif not isinstance(val, text_type):
-            val = text_type(val)
-    else:
-        if isinstance(val, bytes):
-            val = val.decode("utf-8")
-        elif not isinstance(val, str):
-            val = str(val)
+    if isinstance(val, bytes):
+        val = val.decode("utf-8")
+    elif not isinstance(val, str):
+        val = str(val)
 
     return htmlquote(val)
 

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -15,11 +15,9 @@ iteritems = lambda d: iter(d.items())
 # string and text types
 try:
     text_type = unicode
-    string_types = (str, unicode)
     numeric_types = (int, long)
 except NameError:
     text_type = str
-    string_types = (str,)
     numeric_types = (int,)
 
 is_iter = lambda x: x and hasattr(x, "__next__")

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -1,8 +1,5 @@
 """Utilities for make the code run both on Python2 and Python3.
 """
-import sys
-
-PY2 = sys.version_info[0] == 2
 
 # urljoin
 try:
@@ -11,14 +8,9 @@ except ImportError:
     from urlparse import urljoin  # noqa: F401
 
 # Dictionary iteration
-if PY2:
-    iterkeys = lambda d: d.iterkeys()
-    itervalues = lambda d: d.itervalues()
-    iteritems = lambda d: d.iteritems()
-else:
-    iterkeys = lambda d: iter(d.keys())
-    itervalues = lambda d: iter(d.values())
-    iteritems = lambda d: iter(d.items())
+iterkeys = lambda d: iter(d.keys())
+itervalues = lambda d: iter(d.values())
+iteritems = lambda d: iter(d.items())
 
 # string and text types
 try:
@@ -30,13 +22,7 @@ except NameError:
     string_types = (str,)
     numeric_types = (int,)
 
-if PY2:
-    is_iter = lambda x: x and hasattr(x, "next")
-else:
-    is_iter = lambda x: x and hasattr(x, "__next__")
+is_iter = lambda x: x and hasattr(x, "__next__")
 
 # imap
-if PY2:
-    from itertools import imap
-else:
-    imap = map
+imap = map

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -15,10 +15,8 @@ iteritems = lambda d: iter(d.items())
 # string and text types
 try:
     text_type = unicode
-    numeric_types = (int, long)
 except NameError:
     text_type = str
-    numeric_types = (int,)
 
 is_iter = lambda x: x and hasattr(x, "__next__")
 

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -12,12 +12,6 @@ iterkeys = lambda d: iter(d.keys())
 itervalues = lambda d: iter(d.values())
 iteritems = lambda d: iter(d.items())
 
-# string and text types
-try:
-    text_type = unicode
-except NameError:
-    text_type = str
-
 is_iter = lambda x: x and hasattr(x, "__next__")
 
 # imap

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -1,18 +1,9 @@
 """Utilities for make the code run both on Python2 and Python3.
 """
 
-# urljoin
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # noqa: F401
-
 # Dictionary iteration
 iterkeys = lambda d: iter(d.keys())
 itervalues = lambda d: iter(d.values())
 iteritems = lambda d: iter(d.items())
 
 is_iter = lambda x: x and hasattr(x, "__next__")
-
-# imap
-imap = map

--- a/web/session.py
+++ b/web/session.py
@@ -13,7 +13,7 @@ from hashlib import sha1
 
 from . import utils
 from . import webapi as web
-from .py3helpers import PY2, iteritems
+from .py3helpers import iteritems
 
 try:
     import cPickle as pickle
@@ -21,10 +21,7 @@ except ImportError:
     import pickle
 
 
-if PY2:
-    from base64 import encodestring as encodebytes, decodestring as decodebytes
-else:
-    from base64 import encodebytes, decodebytes
+from base64 import encodebytes, decodebytes
 
 
 __all__ = ["Session", "SessionExpired", "Store", "DiskStore", "DBStore"]
@@ -189,9 +186,7 @@ class Session(object):
             secret_key = self._config.secret_key
 
             hashable = "%s%s%s%s" % (rand, now, utils.safestr(web.ctx.ip), secret_key)
-            # TODO maybe a better way to deal with this, without using an if-statement
-            session_id = sha1(hashable if PY2 else hashable.encode("utf-8"))
-            session_id = session_id.hexdigest()
+            session_id = sha1(hashable.encode("utf-8")).hexdigest()
             if session_id not in self.store:
                 break
         return session_id

--- a/web/test.py
+++ b/web/test.py
@@ -6,8 +6,6 @@ import re
 import sys
 import unittest
 
-from .py3helpers import PY2
-
 TestCase = unittest.TestCase
 TestSuite = unittest.TestSuite
 
@@ -26,28 +24,11 @@ def module_suite(module, classnames=None):
         return unittest.TestLoader().loadTestsFromModule(module)
 
 
-# Little wrapper needed for automatically adapting doctests between Py2 and Py3
-# Source : Dirkjan Ochtman (https://dirkjan.ochtman.nl/writing/2014/07/06/single-source-python-23-doctests.html)
-class Py23DocChecker(doctest.OutputChecker):
-    def check_output(self, want, got, optionflags):
-        if not PY2:
-            # Differences between unicode strings representations : u"foo" -> "foo"
-            want = re.sub("u'(.*?)'", "'\\1'", want)
-            want = re.sub('u"(.*?)"', '"\\1"', want)
-
-            # NameError message has changed
-            want = want.replace("NameError: global name", "NameError: name")
-        else:
-            want = re.sub("^b'(.*?)'", "'\\1'", want)
-            want = re.sub('^b"(.*?)"', '"\\1"', want)
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
-
-
 def doctest_suite(module_names):
     """Makes a test suite from doctests."""
     suite = TestSuite()
     for mod in load_modules(module_names):
-        suite.addTest(doctest.DocTestSuite(mod, checker=Py23DocChecker()))
+        suite.addTest(doctest.DocTestSuite(mod))
     return suite
 
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -20,7 +20,6 @@ from .py3helpers import (
     is_iter,
     iteritems,
     itervalues,
-    string_types,
 )
 
 try:
@@ -1442,7 +1441,7 @@ def sendmail(from_address, to_address, subject, message, headers=None, **kw):
             filename = os.path.basename(getattr(a, "name", ""))
             content_type = getattr(a, "content_type", None)
             mail.attach(filename, a.read(), content_type)
-        elif isinstance(a, string_types):
+        elif isinstance(a, str):
             f = open(a, "rb")
             content = f.read()
             f.close()

--- a/web/utils.py
+++ b/web/utils.py
@@ -372,7 +372,7 @@ def safestr(obj, encoding="utf-8"):
     """
 
     if is_iter(obj):
-        return map(safestr, obj)
+        return [safestr(i) for i in obj]
     else:
         return str(obj)
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -16,7 +16,6 @@ import traceback
 from threading import local as threadlocal
 
 from .py3helpers import (
-    imap,
     is_iter,
     iteritems,
     itervalues,
@@ -373,7 +372,7 @@ def safestr(obj, encoding="utf-8"):
     """
 
     if is_iter(obj):
-        return imap(safestr, obj)
+        return map(safestr, obj)
     else:
         return str(obj)
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -16,13 +16,11 @@ import traceback
 from threading import local as threadlocal
 
 from .py3helpers import (
-    PY2,
     imap,
     is_iter,
     iteritems,
     itervalues,
     string_types,
-    text_type,
 )
 
 try:
@@ -365,32 +363,6 @@ def strips(text, remove):
     return rstrips(lstrips(text, remove), remove)
 
 
-def safeunicode(obj, encoding="utf-8"):
-    r"""
-    Converts any given object to unicode string.
-
-        >>> safeunicode('hello')
-        u'hello'
-        >>> safeunicode(2)
-        u'2'
-        >>> safeunicode('\xe1\x88\xb4')
-        u'\u1234'
-    """
-    t = type(obj)
-    if t is text_type:
-        return obj
-    elif t is bytes:
-        return obj.decode(encoding)
-    elif t in [int, float, bool]:
-        return text_type(obj)
-    # elif hasattr(obj, '__unicode__') or isinstance(obj, unicode):
-    #    return unicode(obj)
-    # else:
-    #    return str(obj).decode(encoding)
-    else:
-        return text_type(obj)
-
-
 def safestr(obj, encoding="utf-8"):
     r"""
     Converts any given object to utf-8 encoded string.
@@ -401,17 +373,14 @@ def safestr(obj, encoding="utf-8"):
         '2'
     """
 
-    if PY2 and isinstance(obj, text_type):
-        return obj.encode(encoding)
-    elif is_iter(obj):
+    if is_iter(obj):
         return imap(safestr, obj)
     else:
         return str(obj)
 
 
-if not PY2:
-    # Since Python3, utf-8 encoded strings and unicode strings are the same thing
-    safeunicode = safestr
+# Since Python3, utf-8 encoded strings and unicode strings are the same thing
+safeunicode = safestr
 
 
 def timelimit(timeout):

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -9,8 +9,8 @@ import pprint
 import sys
 import tempfile
 from io import BytesIO
+from urllib.parse import urljoin
 
-from .py3helpers import urljoin
 from .utils import dictadd, intget, safestr, storage, storify, threadeddict
 
 try:

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 from io import BytesIO
 
-from .py3helpers import PY2, text_type, urljoin
+from .py3helpers import text_type, urljoin
 from .utils import dictadd, intget, safestr, storage, storify, threadeddict
 
 try:

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 from io import BytesIO
 
-from .py3helpers import text_type, urljoin
+from .py3helpers import urljoin
 from .utils import dictadd, intget, safestr, storage, storify, threadeddict
 
 try:
@@ -456,7 +456,7 @@ def rawinput(method=None):
                     ctx._fieldstorage = a
             else:
                 d = data()
-                if isinstance(d, text_type):
+                if isinstance(d, str):
                     d = d.encode("utf-8")
                 fp = BytesIO(d)
                 a = cgiFieldStorage(fp=fp, environ=e, keep_blank_values=1)
@@ -532,31 +532,6 @@ def setcookie(
     header("Set-Cookie", value)
 
 
-def decode_cookie(value):
-    r"""Safely decodes a cookie value to unicode.
-
-    Tries us-ascii, utf-8 and io8859 encodings, in that order.
-
-    >>> decode_cookie('')
-    u''
-    >>> decode_cookie('asdf')
-    u'asdf'
-    >>> decode_cookie('foo \xC3\xA9 bar')
-    u'foo \xe9 bar'
-    >>> decode_cookie('foo \xE9 bar')
-    u'foo \xe9 bar'
-    """
-    try:
-        # First try plain ASCII encoding
-        return text_type(value, "us-ascii")
-    except UnicodeError:
-        # Then try UTF-8, and if that fails, ISO8859
-        try:
-            return text_type(value, "utf-8")
-        except UnicodeError:
-            return text_type(value, "iso8859", "ignore")
-
-
 def parse_cookies(http_cookie):
     r"""Parse a HTTP_COOKIE header and return dict of cookie names and decoded values.
 
@@ -620,10 +595,6 @@ def cookies(*requireds, **defaults):
 
     The values are converted to unicode if _unicode=True is passed.
     """
-    # If _unicode=True is specified, use decode_cookie to convert cookie value to unicode
-    if defaults.get("_unicode") is True:
-        defaults["_unicode"] = decode_cookie
-
     # parse cookie string and cache the result for next time.
     if "_parsed_cookies" not in ctx:
         http_cookie = ctx.env.get("HTTP_COOKIE", "")


### PR DESCRIPTION
Drop py2 support:

- Remove all `if PY2:` checks.
- Remove `py3helpers.{string_types,numeric_types,text_type,imap,urljoin}`.
- Remove `decode_cookie`.
- Remove support for MySQL driver `MySQLdb`, it does not work with py3 at all.
- Disable py2 in Travis CI and GitHub Actions.