### PR TITLE
Replace `os.rename()` by `shutil.move` for better Windows support.

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -6,6 +6,7 @@ Session Management
 import datetime
 import os
 import os.path
+import shutil
 import threading
 import time
 from copy import deepcopy
@@ -295,7 +296,7 @@ class DiskStore(Store):
                 f.write(pickled)
             finally:
                 f.close()
-                os.rename(tname, path)  # atomary operation
+                shutil.move(tname, path)  # atomary operation
         except IOError:
             pass
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -7,6 +7,7 @@ General Utilities
 import datetime
 import os
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -759,7 +760,7 @@ def safewrite(filename, content):
     """
     with open(filename + ".tmp", "w") as f:
         f.write(content)
-    os.rename(f.name, filename)
+    shutil.move(f.name, filename)
 
 
 def dictreverse(mapping):


### PR DESCRIPTION
fixes #589