### PR TITLE
Fix incorrect str/bytes type of session data.

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -240,9 +240,9 @@ class Store:
     def decode(self, session_data):
         """decodes the data to get back the session dict """
         if isinstance(session_data, str):
-            pickled = decodebytes(session_data.encode())
-        else:
-            pickled = decodebytes(session_data)
+            session_data = session_data.encode()
+
+        pickled = decodebytes(session_data)
         return pickle.loads(pickled)
 
 
@@ -347,7 +347,8 @@ class DBStore(Store):
             return self.decode(s.data)
 
     def __setitem__(self, key, value):
-        pickled = self.encode(value)
+        # Remove the leading `b` of bytes object.
+        pickled = self.encode(value).decode()
         now = datetime.datetime.now()
         if key in self:
             self.db.update(

--- a/web/session.py
+++ b/web/session.py
@@ -239,7 +239,10 @@ class Store:
 
     def decode(self, session_data):
         """decodes the data to get back the session dict """
-        pickled = decodebytes(session_data)
+        if isinstance(session_data, str):
+            pickled = decodebytes(session_data.encode())
+        else:
+            pickled = decodebytes(session_data)
         return pickle.loads(pickled)
 
 

--- a/web/session.py
+++ b/web/session.py
@@ -347,8 +347,10 @@ class DBStore(Store):
             return self.decode(s.data)
 
     def __setitem__(self, key, value):
-        # Remove the leading `b` of bytes object.
+        # Remove the leading `b` of bytes object (`b"..."`), otherwise encoded
+        # value is invalid base64 format.
         pickled = self.encode(value).decode()
+
         now = datetime.datetime.now()
         if key in self:
             self.db.update(


### PR DESCRIPTION
Fixes #644

Works with:
- MySQL column type `TEXT` and `VARBINARY`
- PostgreSQL column type `TEXT` and `bytea`

py3 code i used for testing:

```
import web

web.config.debug = False

urls = (
    "/count", "count",
)

app = web.application(urls, locals())

conn = web.database(
    dbn='mysql',    # Use `postgres` for PostgreSQL
    host='localhost',
    port=3306,    # Use `5432` for PostgreSQL
    db='<db-name>',
    user='<db-user>',
    pw='<db-password>',
)

session = web.session.Session(
    app=app,
    store=web.session.DBStore(conn, "sessions"),
    initializer={"count": 0},
)

class count:
    def GET(self):
        session.count += 1
        return str(session.count)

if __name__ == "__main__":
    app.run()
```