### PR TITLE
Re-enable MySQL db driver: MySQLdb.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,6 +4,7 @@ pytest>=5.4.1
 
 # DB drivers.
 # mysql
+mysqlclient>=1.4.6
 PyMySQL>=0.9.3
 mysql-connector-python>=8.0.19
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -266,6 +266,21 @@ class SqliteTest_pysqlite2(SqliteTest):
     driver = "pysqlite2.dbapi2"
 
 
+@requires_module("MySQLdb")
+class MySQLTest_MySQLdb(DBTest):
+    dbname = "mysql"
+    driver = "MySQLdb"
+
+    def setUp(self):
+        self.db = setup_database(self.dbname, driver=self.driver)
+        # In mysql, transactions are supported only with INNODB engine.
+        self.db.query("CREATE TABLE person (name text, email text) ENGINE=INNODB")
+
+    def testBoolean(self):
+        # boolean datatype is not supported in MySQL (at least until v5.0)
+        pass
+
+
 @requires_module("pymysql")
 class MySQLTest_PYMYSQL(DBTest):
     dbname = "mysql"

--- a/web/application.py
+++ b/web/application.py
@@ -706,7 +706,7 @@ def unloadhook(h):
             h()
             raise
 
-        if result and hasattr(result, "__next"):
+        if result and hasattr(result, "__next__"):
             return wrap(result)
         else:
             h()

--- a/web/application.py
+++ b/web/application.py
@@ -320,7 +320,7 @@ class application:
                     raise web.nomethod()
 
                 result = self.handle_with_processors()
-                if hasattr(result, "__next__"):
+                if result and hasattr(result, "__next__"):
                     result = peep(result)
                 else:
                     result = [result]
@@ -701,13 +701,12 @@ def unloadhook(h):
     def processor(handler):
         try:
             result = handler()
-            is_gen = hasattr(result, "__next__")
         except:
             # run the hook even when handler raises some exception
             h()
             raise
 
-        if is_gen:
+        if result and hasattr(result, "__next"):
             return wrap(result)
         else:
             h()

--- a/web/application.py
+++ b/web/application.py
@@ -15,7 +15,7 @@ from . import browser, httpserver, utils
 from . import webapi as web
 from . import wsgi
 from .debugerror import debugerror
-from .py3helpers import is_iter, iteritems
+from .py3helpers import iteritems
 from .utils import lstrips
 
 from urllib.parse import urlparse, urlencode, unquote
@@ -320,7 +320,7 @@ class application:
                     raise web.nomethod()
 
                 result = self.handle_with_processors()
-                if is_iter(result):
+                if hasattr(result, "__next__"):
                     result = peep(result)
                 else:
                     result = [result]
@@ -701,7 +701,7 @@ def unloadhook(h):
     def processor(handler):
         try:
             result = handler()
-            is_gen = is_iter(result)
+            is_gen = hasattr(result, "__next__")
         except:
             # run the hook even when handler raises some exception
             h()

--- a/web/db.py
+++ b/web/db.py
@@ -54,9 +54,9 @@ TOKEN = "[ \\f\\t]*(\\\\\\r?\\n[ \\f\\t]*)*(#[^\\r\\n]*)?(((\\d+[jJ]|((\\d+\\.\\
 tokenprog = re.compile(TOKEN)
 
 # Supported db drivers.
-pg_drivers = ["psycopg2"]
-mysql_drivers = ["pymysql", "MySQLdb", "mysql.connector"]
-sqlite_drivers = ["sqlite3", "pysqlite2.dbapi2", "sqlite"]
+pg_drivers = ("psycopg2")
+mysql_drivers = ("pymysql", "MySQLdb", "mysql.connector")
+sqlite_drivers = ("sqlite3", "pysqlite2.dbapi2", "sqlite")
 
 
 class UnknownDB(Exception):
@@ -1286,7 +1286,7 @@ def import_driver(drivers, preferred=None):
     """Import the first available driver or preferred driver.
     """
     if preferred:
-        drivers = [preferred]
+        drivers = (preferred, )
 
     for d in drivers:
         try:

--- a/web/db.py
+++ b/web/db.py
@@ -1253,7 +1253,11 @@ class MySQLDB(DB):
                 keywords["password"] = keywords["pw"]
                 del keywords["pw"]
 
-        if db.__name__ == "mysql.connector":
+        elif db.__name__ == "MySQLdb":
+            if "pw" in keywords:
+                keywords["passwd"] = keywords.pop("pw")
+
+        elif db.__name__ == "mysql.connector":
             # Enabled buffered so that len can work as expected.
             keywords.setdefault("buffered", True)
 

--- a/web/db.py
+++ b/web/db.py
@@ -54,7 +54,7 @@ TOKEN = "[ \\f\\t]*(\\\\\\r?\\n[ \\f\\t]*)*(#[^\\r\\n]*)?(((\\d+[jJ]|((\\d+\\.\\
 tokenprog = re.compile(TOKEN)
 
 # Supported db drivers.
-pg_drivers = ("psycopg2")
+pg_drivers = ("psycopg2",)
 mysql_drivers = ("pymysql", "MySQLdb", "mysql.connector")
 sqlite_drivers = ("sqlite3", "pysqlite2.dbapi2", "sqlite")
 
@@ -1286,7 +1286,7 @@ def import_driver(drivers, preferred=None):
     """Import the first available driver or preferred driver.
     """
     if preferred:
-        drivers = (preferred, )
+        drivers = (preferred,)
 
     for d in drivers:
         try:

--- a/web/db.py
+++ b/web/db.py
@@ -55,7 +55,7 @@ tokenprog = re.compile(TOKEN)
 
 # Supported db drivers.
 pg_drivers = ["psycopg2"]
-mysql_drivers = ["pymysql", "mysql.connector"]
+mysql_drivers = ["pymysql", "MySQLdb", "mysql.connector"]
 sqlite_drivers = ["sqlite3", "pysqlite2.dbapi2", "sqlite"]
 
 

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -5,5 +5,3 @@
 iterkeys = lambda d: iter(d.keys())
 itervalues = lambda d: iter(d.values())
 iteritems = lambda d: iter(d.items())
-
-is_iter = lambda x: x and hasattr(x, "__next__")

--- a/web/utils.py
+++ b/web/utils.py
@@ -370,7 +370,7 @@ def safestr(obj, encoding="utf-8"):
         '2'
     """
 
-    if hasattr(obj, "__next__"):
+    if obj and hasattr(obj, "__next__"):
         return [safestr(i) for i in obj]
     else:
         return str(obj)

--- a/web/utils.py
+++ b/web/utils.py
@@ -16,7 +16,6 @@ import traceback
 from threading import local as threadlocal
 
 from .py3helpers import (
-    is_iter,
     iteritems,
     itervalues,
 )
@@ -371,7 +370,7 @@ def safestr(obj, encoding="utf-8"):
         '2'
     """
 
-    if is_iter(obj):
+    if hasattr(obj, "__next__"):
         return [safestr(i) for i in obj]
     else:
         return str(obj)


### PR DESCRIPTION
2 changes in this PR:

- Re-enable MySQL db driver: MySQLdb.
  - pypi package name: `mysqlclient`. https://pypi.org/project/mysqlclient/
  - It's a fork of old MySQLdb driver with Python 3 support,  according to GitHuB commit log, it's still under active maintenance: https://github.com/PyMySQL/mysqlclient-python/commits/master
  - It's the only one mysql db driver on OpenBSD 6.7, but -snapshot branch has pymysql too.

- Drop py2 support: Remove `py3helpers.is_iter`.