### PR TITLE
WIP: Implement safe context nesting

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -1270,24 +1270,8 @@ class ThreadedDict(threadlocal):
         1
     """
 
-    _instances = set()
-
-    def __init__(self):
-        ThreadedDict._instances.add(self)
-
-    def __del__(self):
-        ThreadedDict._instances.remove(self)
-
     def __hash__(self):
         return id(self)
-
-    def clear_all():
-        """Clears all ThreadedDict instances.
-        """
-        for t in list(ThreadedDict._instances):
-            t.clear()
-
-    clear_all = staticmethod(clear_all)
 
     # Define all these methods to more or less fully emulate dict -- attribute access
     # is built into threading.local.

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -7,6 +7,7 @@ import cgi
 import pprint
 import sys
 import tempfile
+from contextlib import contextmanager
 from io import BytesIO
 from urllib.parse import urljoin
 
@@ -670,6 +671,28 @@ A `storage` object containing various information about the request:
 `output`
    : A string to be used as the response.
 """
+
+
+@contextmanager
+def guard_ctx():
+    """Keep a copy of the current ``web.ctx``.
+
+    If this application is nested inside another webpy application, this
+    context manager protects the outer application from interference.
+
+    """
+
+    # NOTE: `web.ctx` is a thread-local and contains state for requests
+    #   that are executing concurrently in other threads (if any).  We
+    #   cannot simply replace the instance with a fresh one.
+    old_ctx = storage(ctx)
+    ctx.clear()
+    try:
+        yield
+    finally:
+        ctx.clear()
+        ctx.update(old_ctx)
+
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
Before this change, the WSGI application callable assumed it had control
over `web.ctx` over its entire duration.  If you embed a `web.py`
application within another `web.py` application *without* using the
sub-applications feature, this assumption is not safe.  What happens is
the inner application clears `web.ctx` without saving and the outer
application's WSGI callable finishes its execution with the final
`web.ctx` of the inner application.

Of course, this is not a common usage of `web.py`.  It happens in
situations such as in-process routing of requests between multiple
micro-services implemented using `web.py`.

Should fix #268.