### PR TITLE
Make sure session DiskStore `cleanup()` correctly returns when session directory was removed.

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -45,7 +45,7 @@ jobs:
           black --check .
       - run: codespell . --ignore-words-list=eith,gae --skip=./.* --quiet-level=2
       - run: flake8 --count --ignore=E203,E265,E722,E731,W503 --max-line-length=477 --show-source --statistics
-      - run: isort --recursive .
+      - run: isort .
 
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,9 @@
 import os
+import time
 import tempfile
 import threading
 import unittest
+import shutil
 
 import web
 
@@ -84,6 +86,17 @@ class SessionTest(unittest.TestCase):
 
 
 class DiskStoreTest(unittest.TestCase):
+    def testRemovedSessionDir(self):
+        # make sure `cleanup()` correctly returns when session directory was
+        # removed.
+        dir = tempfile.mkdtemp()
+        s = web.session.DiskStore(dir)
+        s["count"] = 20
+        self.assertEqual(s["count"], 20)
+        shutil.rmtree(dir)
+        time.sleep(2)
+        s.cleanup(1)
+
     def testStoreConcurrent(self):
         dir = tempfile.mkdtemp()
         store = web.session.DiskStore(dir)

--- a/web/session.py
+++ b/web/session.py
@@ -309,13 +309,15 @@ class DiskStore(Store):
             os.remove(path)
 
     def cleanup(self, timeout):
-        if os.path.isdir(self.root):
-            now = time.time()
-            for f in os.listdir(self.root):
-                path = self._get_path(f)
-                atime = os.stat(path).st_atime
-                if now - atime > timeout:
-                    shutil.rmtree(path)
+        if not os.path.isdir(self.root):
+            return
+
+        now = time.time()
+        for f in os.listdir(self.root):
+            path = self._get_path(f)
+            atime = os.stat(path).st_atime
+            if now - atime > timeout:
+                shutil.rmtree(path)
 
 
 class DBStore(Store):

--- a/web/session.py
+++ b/web/session.py
@@ -310,11 +310,12 @@ class DiskStore(Store):
 
     def cleanup(self, timeout):
         now = time.time()
-        for f in os.listdir(self.root):
-            path = self._get_path(f)
-            atime = os.stat(path).st_atime
-            if now - atime > timeout:
-                os.remove(path)
+        if os.path.isdir(self.root):
+            for f in os.listdir(self.root):
+                path = self._get_path(f)
+                atime = os.stat(path).st_atime
+                if now - atime > timeout:
+                    shutil.rmtree(path)
 
 
 class DBStore(Store):

--- a/web/session.py
+++ b/web/session.py
@@ -309,8 +309,8 @@ class DiskStore(Store):
             os.remove(path)
 
     def cleanup(self, timeout):
-        now = time.time()
         if os.path.isdir(self.root):
+            now = time.time()
             for f in os.listdir(self.root):
                 path = self._get_path(f)
                 atime = os.stat(path).st_atime


### PR DESCRIPTION
I recently experienced an issue with app using DiskStore as session store. Seems client didn't visit website for long enough to  trigger the session timeout, also the session directory was removed, when this client visit the website, web.py still tries to check the info of its seession id, since the session directory was removed, this raises exception `OSError` or `FileNotFoundError`.

This PR should fix this issue by checking session directory existence before running `os.path.listdir()`, unittest included.