### PR TITLE
Release version 0.61

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,9 @@
 # web.py changelog
 
+## 2020-06-23 0.61
+
+* setup.py: Add python_requires='>=3.5' #662
+
 ## 2020-06-23 0.60
 
 * Python-2 support has been completely dropped. Welcome to Python 3.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you are still using Python 2.7, then please use web.py version 0.51
 which is intended to be our last release that supports Python 2. 
 ```
 # For Python 2.7
-pip2 install web.py==0.51
+python2 -m pip install web.py==0.51
 ```
 
 You can also download it from [GitHub Releases](https://github.com/webpy/webpy/releases)

--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@ Visit http://webpy.org/ for more information.
 [![build status](https://secure.travis-ci.org/webpy/webpy.png?branch=master)](https://travis-ci.org/webpy/webpy)
 [![Codecov Test Coverage](https://codecov.io/gh/webpy/webpy/branch/master/graphs/badge.svg?style=flat)](https://codecov.io/gh/webpy/webpy)
 
-The latest stable release `0.60` only supports supports Python >= 3.5.
+The latest stable release `0.61` only supports Python >= 3.5.
 To install it, please run:
-
 ```
 # For Python 3
-python3 -m pip install web.py==0.60
+python3 -m pip install web.py==0.61
 ```
 
-If you are using Python 2, please use the 0.51 version. Please note that
-this is the last version that supports Python 2. 
+If you are still using Python 2.7, then please use web.py version 0.51
+which is intended to be our last version that supports Python 2. 
 ```
 # For Python 2.7
 pip2 install web.py==0.51
@@ -22,12 +21,10 @@ pip2 install web.py==0.51
 
 You can also download it from [GitHub Releases](https://github.com/webpy/webpy/releases)
 page, then install it manually:
-
 ```
-unzip webpy-0.60.zip
-cd webpy-0.60/
+unzip webpy-0.61.zip
+cd webpy-0.61/
 python3 setup.py install
 ```
 
-Note: `0.5x` (e.g. 0.50, 0.51) is the last release which supports Python 2.
-Future releases will drop support for Python 2.
+Note: `0.5x` (e.g. 0.50, 0.51) are our last releases which supports Python 2.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python3 -m pip install web.py==0.61
 ```
 
 If you are still using Python 2.7, then please use web.py version 0.51
-which is intended to be our last version that supports Python 2. 
+which is intended to be our last release that supports Python 2. 
 ```
 # For Python 2.7
 pip2 install web.py==0.51
@@ -27,4 +27,4 @@ cd webpy-0.61/
 python3 setup.py install
 ```
 
-Note: `0.5x` (e.g. 0.50, 0.51) are our last releases which supports Python 2.
+Note: `0.5x` (e.g. 0.50, 0.51) are our last releases which support Python 2.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Public domain",
     platforms=["any"],
+    python_requires='>=3.5',
     classifiers=[
         "License :: Public Domain",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Public domain",
     platforms=["any"],
-    python_requires='>=3.5',
+    python_requires=">=3.5",
     classifiers=[
         "License :: Public Domain",
         "Programming Language :: Python",

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -24,7 +24,7 @@ from .utils import *  # noqa: F401,F403
 from .webapi import *  # noqa: F401,F403
 from .wsgi import *  # noqa: F401,F403
 
-__version__ = "0.60"
+__version__ = "0.61"
 __author__ = [
     "Aaron Swartz <me@aaronsw.com>",
     "Anand Chitipothu <anandology@gmail.com>",


### PR DESCRIPTION
setup.py: Add `python_requires='>=3.5'`

This prevents installation on legacy Python and other versions < Python 3.5 as discussed in
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

Tasks for making a new release.
- [ ] Reread [__Packaging Python Projects__](https://packaging.python.org/tutorials/packaging-projects) to make sure you miss no steps...
- [x] Bump the version in `web/__init__.py`
- [x] Update `ChangeLog.txt` and mark the release date in ChangeLog.txt
- [x] Check `setup.py` and update if necessary
- [x] Check `README.md` and update if necessary
- [x] Check `MANIFEST.in` and update if necessary  #628
- [x] Tag the version and mark it as a release in GitHub
- [ ] `python3 -m pip install --upgrade pip wheel `  # Important for PyPI page rendering
- [ ] build dist of the package and publish on pypi (`python3 setup.py sdist upload`)
- [ ] Update the documentation on the website (see [webpy.github.com](https://github.com/webpy/webpy.github.com) repo)
- [ ] Announce it on the mailing list
- [ ] Update the API docs if required