### PR TITLE
Remove python2 code

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -20,10 +20,7 @@ from .utils import lstrips
 
 from urllib.parse import urlparse, urlencode, unquote
 
-try:
-    reload  # Python 2
-except NameError:
-    from importlib import reload  # Python 3
+from importlib import reload
 
 
 __all__ = [

--- a/web/http.py
+++ b/web/http.py
@@ -24,19 +24,13 @@ try:
 except ImportError:
     from urllib import urlencode as urllib_urlencode
 
-try:
-    xrange  # Python 2
-except NameError:
-    xrange = range  # Python 3
-
-
 def prefixurl(base=""):
     """
     Sorry, this function is really difficult to explain.
     Maybe some other time.
     """
     url = web.ctx.path.lstrip("/")
-    for i in xrange(url.count("/")):
+    for i in range(url.count("/")):
         base += "../"
     if not base:
         base = "./"

--- a/web/http.py
+++ b/web/http.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     from urllib import urlencode as urllib_urlencode
 
+
 def prefixurl(base=""):
     """
     Sorry, this function is really difficult to explain.


### PR DESCRIPTION
Because we only support python 3,  checks for Python 2 are no longer necessary.