### PR TITLE
Define a repr() for templates to ease debugging

### DIFF
--- a/web/template.py
+++ b/web/template.py
@@ -942,6 +942,22 @@ class Template(BaseTemplate):
             builtins=builtins,
         )
 
+    def __repr__(self):
+        """
+        >>> Template('Template text', 'burndown_chart.html')
+        Template(text="Template text", filename="burndown_chart.html")
+
+        >>> Template('This is too much text with /t & /n characters', 'index.html')
+        Template(text="This is too much text with /t & /n chara", filename="index.html")
+        """
+        try:
+            class_name = self.__class__.__qualname__
+        except AttributeError:
+            class_name = self.__class__.__name__
+        return '{}(text="{}", filename="{}")'.format(
+            class_name, self.text[:40], self.filename
+        )
+
     def normalize_text(text):
         """Normalizes template text by correcting \r\n, tabs and BOM chars."""
         text = text.replace("\r\n", "\n").replace("\r", "\n").expandtabs()

--- a/web/template.py
+++ b/web/template.py
@@ -944,11 +944,8 @@ class Template(BaseTemplate):
 
     def __repr__(self):
         """
-        >>> Template('Template text', 'burndown_chart.html')
+        >>> Template(text='Template text', filename='burndown_chart.html')
         <Template burndown_chart.html>
-
-        >>> Template('This is too much text with /t & /n characters', 'index.html')
-        <Template index.html>
         """
         return "<{} {}>".format(self.__class__.__name__, self.filename)
 

--- a/web/template.py
+++ b/web/template.py
@@ -945,18 +945,12 @@ class Template(BaseTemplate):
     def __repr__(self):
         """
         >>> Template('Template text', 'burndown_chart.html')
-        Template(text="Template text", filename="burndown_chart.html")
+        <Template burndown_chart.html>
 
         >>> Template('This is too much text with /t & /n characters', 'index.html')
-        Template(text="This is too much text with /t & /n chara", filename="index.html")
+        <Template index.html>
         """
-        try:
-            class_name = self.__class__.__qualname__
-        except AttributeError:
-            class_name = self.__class__.__name__
-        return '{}(text="{}", filename="{}")'.format(
-            class_name, self.text[:40], self.filename
-        )
+        return "<{} {}>".format(self.__class__.__name__, self.filename)
 
     def normalize_text(text):
         """Normalizes template text by correcting \r\n, tabs and BOM chars."""


### PR DESCRIPTION
When debugging, templates appear as `<web.template.Template instance at 0x4036ab8>` which does not aid the developer.

This PR proposes `Template(text="Template text", filename="burndown_chart.html")` instead.