### PR TITLE
Revert an incorrect cookie modification

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -153,11 +153,7 @@ class Session(object):
             self.store[self.session_id] = dict(self._data)
         else:
             if web.cookies().get(self._config.cookie_name):
-                self._setcookie(
-                    self.session_id,
-                    expires=self._config.timeout,
-                    samesite=self._config.get("samesite"),
-                )
+                self._setcookie(self.session_id, expires=-1)
 
     def _setcookie(self, session_id, expires="", **kw):
         cookie_name = self._config.cookie_name
@@ -213,11 +209,6 @@ class Session(object):
         """Kill the session, make it no longer available"""
         del self.store[self.session_id]
         self._killed = True
-
-        # Expire the cookie
-        web.setcookie(self._config.cookie_name,
-                      self.session_id,
-                      expires=-1)
 
 
 class Store:

--- a/web/session.py
+++ b/web/session.py
@@ -214,6 +214,11 @@ class Session(object):
         del self.store[self.session_id]
         self._killed = True
 
+        # Expire the cookie
+        web.setcookie(self._config.cookie_name,
+                      self.session_id,
+                      expires=-1)
+
 
 class Store:
     """Base class for session stores"""


### PR DESCRIPTION
Commit https://github.com/webpy/webpy/commit/651ea426de61e71ce0ab8a304dbefd29d4611b62#diff-8a8747d48229930871bbbe6e4bd8767eL152 incorrectly modified the cookie state after session killed. It causes browser cookie not cleaned up and web browser session may behave incorrectly.

I experienced the error and fixed it by reverted old commit, tested locally and on production server, both work fine now.