### PR TITLE
Start testing on Python 3.9 and stop on EOL Py3.5

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -34,18 +34,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@master
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip install codespell flake8 isort pytest
-      - if: matrix.python-version >= 3.6
-        run: |
-          pip install black
-          black --check .
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check .
       - run: codespell . --ignore-words-list=eith,gae --skip=./.* --quiet-level=2
       - run: flake8 --count --ignore=E203,E265,E722,E731,W503 --max-line-length=477 --show-source --statistics
-      - run: isort .
+      - run: isort --profile black .
 
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # TODO: (cclauss) add pypy3  https://github.com/webpy/webpy/issues/598
-        python-version: [3.5, 3.6, 3.7, 3.8]  # , pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9]  # , pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Visit http://webpy.org/ for more information.
 [![build status](https://secure.travis-ci.org/webpy/webpy.png?branch=master)](https://travis-ci.org/webpy/webpy)
 [![Codecov Test Coverage](https://codecov.io/gh/webpy/webpy/branch/master/graphs/badge.svg?style=flat)](https://codecov.io/gh/webpy/webpy)
 
-The latest stable release `0.61` only supports Python >= 3.5.
+The latest stable release `0.61` only supports Python >= 3.6.
 To install it, please run:
 ```
 # For Python 3

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ setup(
         "License :: Public Domain",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Public domain",
     platforms=["any"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         "License :: Public Domain",
         "Programming Language :: Python",


### PR DESCRIPTION
* https://devguide.python.org/devcycle/#end-of-life-branches
* https://devguide.python.org/#status-of-python-branches