### PR TITLE
docs: fix simple typo, resvere -> reverse

### DIFF
--- a/web/application.py
+++ b/web/application.py
@@ -286,7 +286,7 @@ class application:
                 print(traceback.format_exc(), file=web.debug)
                 raise self.internalerror()
 
-        # processors must be applied in the resvere order. (??)
+        # processors must be applied in the reverse order. (??)
         return process(self.processors)
 
     def wsgifunc(self, *middleware):


### PR DESCRIPTION
There is a small typo in web/application.py.

Should read `reverse` rather than `resvere`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md