### PR TITLE
MANIFEST.in: include LICENSE.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE.txt
 include requirements.txt
 include test_requirements.txt
 recursive-include docs *


### PR DESCRIPTION
Since version 0.61 and commit e0be57be1f032f76cbf253e960cb635239b56ec3, the official pypi tarballs don't ship `LICENSE.txt` anymore.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>