### PR TITLE
test: pin dbutils to >= 2.0.0

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 cheroot>=6.0.0
-DBUtils
+DBUtils>=2.0.0
 pytest>=5.4.1
 
 # DB drivers.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -147,12 +147,12 @@ class DBTest(unittest.TestCase):
     def testPooling(self):
         # can't test pooling if DBUtils is not installed
         try:
-            import DBUtils  # noqa
+            import dbutils  # noqa
         except ImportError:
             return
         db = setup_database(self.dbname, pooling=True)
         try:
-            self.assertEqual(db.ctx.db.__class__.__module__, "DBUtils.PooledDB")
+            self.assertEqual(db.ctx.db.__class__.__module__, "dbutils.PooledDB")
             db.select("person", limit=1)
         finally:
             db.ctx.db.close()

--- a/web/db.py
+++ b/web/db.py
@@ -656,7 +656,7 @@ class DB:
         self.supports_multiple_insert = False
 
         try:
-            import DBUtils  # noqa, flake8 F401
+            import dbutils  # noqa, flake8 F401
 
             # enable pooling if DBUtils module is available.
             self.has_pooling = True
@@ -712,7 +712,7 @@ class DB:
 
     def _connect_with_pooling(self, keywords):
         def get_pooled_db():
-            from DBUtils import PooledDB
+            from dbutils import PooledDB
 
             # In DBUtils 0.9.3, `dbapi` argument is renamed as `creator`
             # see Bug#122112


### PR DESCRIPTION
dbutils 2.0.0 includes breaking changes where the import is done through lowercase letters: `import dbutils` instead of `import DBUtils`

Ref: https://webwareforpython.github.io/DBUtils/changelog.html

Fixes: #710 