### PR TITLE
utils.py: Make `iters` a real tuple, not a hacked tuple

### DIFF
--- a/web/session.py
+++ b/web/session.py
@@ -233,7 +233,7 @@ class Store:
         return encodebytes(pickled)
 
     def decode(self, session_data):
-        """decodes the data to get back the session dict """
+        """decodes the data to get back the session dict"""
         if isinstance(session_data, str):
             session_data = session_data.encode()
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -290,17 +290,9 @@ class Counter(storage):
 
 counter = Counter
 
-iters = [list, tuple, set, frozenset]
-
-
-class _hack(tuple):
-    pass
-
-
-iters = _hack(iters)
+iters = (list, tuple, set, frozenset)
 iters.__doc__ = """
-A list of iterable items (like lists, but not strings). Includes whichever
-of lists, tuples, sets, and Sets are available in this version of Python.
+A list of iterable items like list, tuple, set, and frozenset but not strings.
 """
 
 

--- a/web/utils.py
+++ b/web/utils.py
@@ -289,11 +289,7 @@ class Counter(storage):
 
 
 counter = Counter
-
 iters = (list, tuple, set, frozenset)
-iters.__doc__ = """
-A list of iterable items like list, tuple, set, and frozenset but not strings.
-"""
 
 
 def _strips(direction, text, remove):


### PR DESCRIPTION
We no longer need to support Python 2.3 so remove the `_hack()` which was meant to support a Python before `set()` and `frozenset()`.

All [uses of `iters`](https://github.com/webpy/webpy/search?q=iters) are for use as the second parameter to `isinstance()` which must be a tuple, not a list.