### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     maintainer="Anand Chitipothu",
     maintainer_email="anandology@gmail.com",
     url="http://webpy.org/",
+    project_urls={
+        "Source": "https://github.com/webpy/webpy",
+    },
     packages=["web", "web.contrib"],
     install_requires=["cheroot"],
     long_description=long_description,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -298,8 +298,8 @@ class ApplicationTest(unittest.TestCase):
             path = "/?" + urlencode({"name": name.encode("utf-8")})
             self.assertEqual(app.request(path).data.decode("utf-8"), repr(name))
 
-        f(u"\u1234")
-        f(u"foo")
+        f("\u1234")
+        f("foo")
 
         response = app.request("/", method="POST", data=dict(name="foo"))
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -93,7 +93,7 @@ class DBTest(unittest.TestCase):
 
     def testUnicode(self):
         # Bug#177265: unicode queries throw errors
-        self.db.select("person", where="name=$name", vars={"name": u"\xf4"})
+        self.db.select("person", where="name=$name", vars={"name": "\xf4"})
 
     def assertRows(self, n):
         result = self.db.select("person")

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -16,7 +16,7 @@ class WSGITest(unittest.TestCase):
 
         class uni:
             def GET(self):
-                return u"\u0C05\u0C06"
+                return "\u0C05\u0C06"
 
         app = web.application(urls, locals())
 
@@ -27,7 +27,7 @@ class WSGITest(unittest.TestCase):
         b = web.browser.AppBrowser(app)
         r = b.open("/").read()
         s = r.decode("utf8")
-        self.assertEqual(s, u"\u0C05\u0C06")
+        self.assertEqual(s, "\u0C05\u0C06")
 
         app.stop()
         thread.join()

--- a/web/net.py
+++ b/web/net.py
@@ -228,11 +228,11 @@ def htmlquote(text):
         >>> htmlquote(u"<'&\">")
         u'&lt;&#39;&amp;&quot;&gt;'
     """
-    text = text.replace(u"&", u"&amp;")  # Must be done first!
-    text = text.replace(u"<", u"&lt;")
-    text = text.replace(u">", u"&gt;")
-    text = text.replace(u"'", u"&#39;")
-    text = text.replace(u'"', u"&quot;")
+    text = text.replace("&", "&amp;")  # Must be done first!
+    text = text.replace("<", "&lt;")
+    text = text.replace(">", "&gt;")
+    text = text.replace("'", "&#39;")
+    text = text.replace('"', "&quot;")
     return text
 
 
@@ -243,11 +243,11 @@ def htmlunquote(text):
         >>> htmlunquote(u'&lt;&#39;&amp;&quot;&gt;')
         u'<\'&">'
     """
-    text = text.replace(u"&quot;", u'"')
-    text = text.replace(u"&#39;", u"'")
-    text = text.replace(u"&gt;", u">")
-    text = text.replace(u"&lt;", u"<")
-    text = text.replace(u"&amp;", u"&")  # Must be done last!
+    text = text.replace("&quot;", '"')
+    text = text.replace("&#39;", "'")
+    text = text.replace("&gt;", ">")
+    text = text.replace("&lt;", "<")
+    text = text.replace("&amp;", "&")  # Must be done last!
     return text
 
 
@@ -263,7 +263,7 @@ def websafe(val):
         True
     """
     if val is None:
-        return u""
+        return ""
 
     if isinstance(val, bytes):
         val = val.decode("utf-8")

--- a/web/template.py
+++ b/web/template.py
@@ -889,7 +889,7 @@ class BaseTemplate:
         )
 
     def _join(self, *items):
-        return u"".join(items)
+        return "".join(items)
 
     def _escape(self, value, escape=False):
         if value is None:
@@ -1437,7 +1437,7 @@ class TemplateResult(MutableMapping):
 
     def __init__(self, *a, **kw):
         self.__dict__["_d"] = dict(*a, **kw)
-        self._d.setdefault("__body__", u"")
+        self._d.setdefault("__body__", "")
 
         self.__dict__["_parts"] = []
         self.__dict__["extend"] = self._parts.extend
@@ -1450,7 +1450,7 @@ class TemplateResult(MutableMapping):
     def _prepare_body(self):
         """Prepare value of __body__ by joining parts."""
         if self._parts:
-            value = u"".join(self._parts)
+            value = "".join(self._parts)
             self._parts[:] = []
             body = self._d.get("__body__")
             if body:


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)