### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10.

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -411,7 +411,7 @@ def timelimit(timeout):
                     self.result = None
                     self.error = None
 
-                    self.setDaemon(True)
+                    self.daemon = True
                     self.start()
 
                 def run(self):


### PR DESCRIPTION
The camelcase methods were deprecated in Python 3.10 in https://github.com/python/cpython/pull/25174