### PR TITLE
chore: remove unnecessary files in generated python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE.txt
 include requirements.txt
 include test_requirements.txt
-recursive-include docs *
-recursive-include tests *
-recursive-include tools *
+recursive-include docs *.rst Makefile
+recursive-include tests *.py


### PR DESCRIPTION
Current build will add unnecessary files, like mypy cache files, pyc files, `.DS_store` files in tests / docs folder, which will be installed on users' machine.

And the `tools` folder will be a namespace package, which will be installed on users' `site-packages`, and makes a 'tools' module which can be imported.