### PR TITLE
refactor: run pyupgrade on exists codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/web/application.py
+++ b/web/application.py
@@ -410,9 +410,7 @@ class application:
             minor = version[1]
 
             if major != 2:
-                raise EnvironmentError(
-                    "Google App Engine only supports python 2.5 and 2.7"
-                )
+                raise OSError("Google App Engine only supports python 2.5 and 2.7")
 
             # if 2.7, return a function that can be run by gae
             if minor == 7:
@@ -423,9 +421,7 @@ class application:
 
                 return run_wsgi_app(wsgiapp)
             else:
-                raise EnvironmentError(
-                    "Not a supported platform, use python 2.5 or 2.7"
-                )
+                raise OSError("Not a supported platform, use python 2.5 or 2.7")
         except ImportError:
             return wsgiref.handlers.CGIHandler().run(wsgiapp)
 
@@ -797,7 +793,7 @@ class Reloader:
 
         try:
             mtime = os.stat(mod.__file__).st_mtime
-        except (OSError, IOError):
+        except OSError:
             return
         if mod.__file__.endswith(self.__class__.SUFFIX) and os.path.exists(
             mod.__file__[:-1]

--- a/web/browser.py
+++ b/web/browser.py
@@ -24,7 +24,7 @@ class BrowserError(Exception):
     pass
 
 
-class Browser(object):
+class Browser:
     def __init__(self):
         self.cookiejar = CookieJar()
         self._cookie_processor = HTTPCookieProcessor(self.cookiejar)

--- a/web/db.py
+++ b/web/db.py
@@ -84,7 +84,7 @@ class UnknownParamstyle(Exception):
     pass
 
 
-class SQLParam(object):
+class SQLParam:
     """
     Parameter in SQLQuery.
 
@@ -133,7 +133,7 @@ class SQLParam(object):
 sqlparam = SQLParam
 
 
-class SQLQuery(object):
+class SQLQuery:
     """
     You can pass this sort of thing as a clause in any db function.
     Otherwise, you can pass a dictionary to the keyword argument `vars`
@@ -286,7 +286,7 @@ class SQLQuery(object):
 
     def _str(self):
         try:
-            return self.query() % tuple([sqlify(x) for x in self.values()])
+            return self.query() % tuple(sqlify(x) for x in self.values())
         except (ValueError, TypeError):
             return self.query()
 
@@ -427,7 +427,7 @@ def sqlors(left, lst):
 
     if isinstance(lst, iters):
         return SQLQuery(
-            ["("] + sum([[left, sqlparam(x), " OR "] for x in lst], []) + ["1=2)"]
+            ["("] + sum(([left, sqlparam(x), " OR "] for x in lst), []) + ["1=2)"]
         )
     else:
         return left + sqlparam(lst)
@@ -1210,7 +1210,7 @@ class PostgresDB(DB):
         """Query postgres to find names of all sequences used in this database."""
         if self._sequences is None:
             q = "SELECT c.relname FROM pg_class c WHERE c.relkind = 'S'"
-            self._sequences = set([c.relname for c in self.query(q)])
+            self._sequences = {c.relname for c in self.query(q)}
         return self._sequences
 
     def _connect(self, keywords):
@@ -1558,7 +1558,7 @@ def _interpolate(format):
     return chunks
 
 
-class _Node(object):
+class _Node:
     def __init__(self, type, first, second=None):
         self.type = type
         self.first = first
@@ -1673,7 +1673,7 @@ class Parser:
         return expr
 
 
-class SafeEval(object):
+class SafeEval:
     """Safe evaluator for binding params to db queries."""
 
     def safeeval(self, text, mapping):

--- a/web/debugerror.py
+++ b/web/debugerror.py
@@ -93,7 +93,7 @@ $def with (exception_type, exception_value, frames)
         var arrElements = (strTagName == "*" && document.all)? document.all :
         oElm.getElementsByTagName(strTagName);
         var arrReturnElements = new Array();
-        strClassName = strClassName.replace(/\-/g, "\\-");
+        strClassName = strClassName.replace(/\\-/g, "\\-");
         var oRegExp = new RegExp("(^|\\s)" + strClassName + "(\\s|$$)");
         var oElement;
         for(var i=0; i<arrElements.length; i++){
@@ -255,7 +255,7 @@ def djangoerror():
             ]
 
             return lower_bound, pre_context, context_line, post_context
-        except (OSError, IOError, IndexError):
+        except (OSError, IndexError):
             return None, [], None, []
 
     exception_type, exception_value, tback = sys.exc_info()

--- a/web/form.py
+++ b/web/form.py
@@ -27,7 +27,7 @@ def attrget(obj, attr, value=None):
     return value
 
 
-class Form(object):
+class Form:
     r"""
     HTML form.
 
@@ -149,7 +149,7 @@ class Form(object):
     d = property(_get_d)
 
 
-class Input(object):
+class Input:
     """Generic input. Type attribute must be specified when called directly.
 
     See also: <https://www.w3.org/TR/html52/sec-forms.html#the-input-element>

--- a/web/http.py
+++ b/web/http.py
@@ -72,9 +72,7 @@ def modified(date=None, etag=None):
     `True`, or otherwise it raises NotModified error. It also sets
     `Last-Modified` and `ETag` output headers.
     """
-    n = set(
-        [x.strip('" ') for x in web.ctx.env.get("HTTP_IF_NONE_MATCH", "").split(",")]
-    )
+    n = {x.strip('" ') for x in web.ctx.env.get("HTTP_IF_NONE_MATCH", "").split(",")}
     m = net.parsehttpdate(web.ctx.env.get("HTTP_IF_MODIFIED_SINCE", "").split(";")[0])
     validate = False
     if etag:
@@ -112,7 +110,7 @@ def urlencode(query, doseq=0):
         else:
             return utils.safestr(value)
 
-    query = dict([(k, convert(v, doseq)) for k, v in query.items()])
+    query = {k: convert(v, doseq) for k, v in query.items()}
     return urllib_urlencode(query, doseq=doseq)
 
 

--- a/web/httpserver.py
+++ b/web/httpserver.py
@@ -91,7 +91,7 @@ def runbasic(func, server_address=("0.0.0.0", 8080)):
                     finally:
                         if hasattr(result, "close"):
                             result.close()
-                except socket.error as socket_err:
+                except OSError as socket_err:
                     # Catch common network errors and suppress them
                     if socket_err.args[0] in (errno.ECONNABORTED, errno.EPIPE):
                         return

--- a/web/net.py
+++ b/web/net.py
@@ -44,7 +44,7 @@ def validip6addr(address):
     """
     try:
         socket.inet_pton(socket.AF_INET6, address)
-    except (socket.error, AttributeError, ValueError):
+    except (OSError, AttributeError, ValueError):
         return False
 
     return True

--- a/web/session.py
+++ b/web/session.py
@@ -49,7 +49,7 @@ class SessionExpired(web.HTTPError):
         web.HTTPError.__init__(self, "200 OK", {}, data=message)
 
 
-class Session(object):
+class Session:
     """Session management for web.py"""
 
     __slots__ = [
@@ -295,7 +295,7 @@ class DiskStore(Store):
             finally:
                 f.close()
                 shutil.move(tname, path)  # atomary operation
-        except IOError:
+        except OSError:
             pass
 
     def __delitem__(self, key):

--- a/web/template.py
+++ b/web/template.py
@@ -33,7 +33,6 @@ import glob
 import os
 import sys
 import tokenize
-from io import open
 import builtins
 
 from .net import websafe
@@ -782,13 +781,11 @@ TEMPLATE_BUILTIN_NAMES = [
     "__import__",  # some c-libraries like datetime requires __import__ to present in the namespace
 ]
 
-TEMPLATE_BUILTINS = dict(
-    [
-        (name, getattr(builtins, name))
-        for name in TEMPLATE_BUILTIN_NAMES
-        if name in builtins.__dict__
-    ]
-)
+TEMPLATE_BUILTINS = {
+    name: getattr(builtins, name)
+    for name in TEMPLATE_BUILTIN_NAMES
+    if name in builtins.__dict__
+}
 
 
 class ForLoop:

--- a/web/utils.py
+++ b/web/utils.py
@@ -768,7 +768,7 @@ def dictreverse(mapping):
         >>> dictreverse({1: 2, 3: 4})
         {2: 1, 4: 3}
     """
-    return dict([(value, key) for (key, value) in iteritems(mapping)])
+    return {value: key for (key, value) in iteritems(mapping)}
 
 
 def dictfind(dictionary, element):
@@ -1198,7 +1198,7 @@ class Profile:
         # remove the tempfile
         try:
             os.remove(filename)
-        except IOError:
+        except OSError:
             pass
 
         return result, x

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -433,7 +433,7 @@ def rawinput(method=None):
         if fs.list is None:
             fs.list = []
 
-        return dict([(k, fs[k]) for k in fs])
+        return {k: fs[k] for k in fs}
 
     e = ctx.env.copy()
     a = b = {}
@@ -568,7 +568,7 @@ def parse_cookies(http_cookie):
                     cookie.load(attr_value)
                 except CookieError:
                     pass
-        cookies = dict([(k, unquote(v.value)) for k, v in cookie.items()])
+        cookies = {k: unquote(v.value) for k, v in cookie.items()}
     else:
         # HTTP_COOKIE doesn't have quotes, use fast cookie parsing
         cookies = {}


### PR DESCRIPTION
The command is `pyupgrade --keep-percent-format --py3-plus`, for we have python 3.5 and upper version support, and I think percent format is not deprecated in near future.