### PR TITLE
Add Python 3.12-dev to the testing

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
 
     steps:
       - uses: actions/checkout@v3
@@ -39,6 +39,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - if: "contains(matrix.python-version, '-dev')"
+        run: sudo apt-get install -y libxml2 libxslt-dev
       - run: pip install black codespell flake8 isort pytest
       - run: black --check .
       - run: codespell . --ignore-words-list=asend,gae --skip=./.*


### PR DESCRIPTION
We are halfway thru the Python 3.12 alpha cycle so let's see if any of the proposed changes break our tests...
* https://peps.python.org/pep-0693/#release-schedule
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3120a4/