### PR TITLE
fix attachment unicodeError

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -1516,7 +1516,12 @@ class _EmailMessage:
 
         if not content_type.startswith("text/"):
             encoders.encode_base64(msg)
-
+        else:
+            try:
+                msg = msg.encode("ascii")
+            except Exception as e:
+                encoders.encode_base64(msg)
+                
         self.message.attach(msg)
 
     def prepare_message(self):


### PR DESCRIPTION
This is a fix to handle emails with attachments that have characters that are not in range(128), in this case we encode them in base64.