### PR TITLE
Replace flake8, isort, and pyupgrade with ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -41,11 +41,10 @@ jobs:
 
       - if: "contains(matrix.python-version, '-dev')"
         run: sudo apt-get install -y libxml2 libxslt-dev
-      - run: pip install black codespell flake8 isort pytest
+      - run: pip install black codespell pytest ruff
       - run: black --check .
       - run: codespell . --ignore-words-list=asend,gae --skip=./.*
-      - run: flake8 --count --ignore=E203,E265,E722,E731,W503 --max-line-length=477 --show-source --statistics
-      - run: isort --profile black .
+      - run: ruff .
 
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,18 @@
 # default_language_version:
 #     python: python3.7
 repos:
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
-    hooks:
-    - id: pyupgrade
-      args: [--py36-plus]
-
 -   repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     - id: black
 
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.253
     hooks:
-    - id: isort
-      args: [--profile, black]
-
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-    - id: flake8
-      args: [--count, "--ignore=E203,E265,E722,E731,W503", --max-line-length=477, --show-source, --statistics]
+    - id: ruff
+      args: [--format, github]  # --fix, --exit-non-zero-on-fix]
 
 -   repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.10.1
+    rev: v0.12.1
     hooks:
     - id: validate-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,12 @@ classifiers = [
     "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.7"
 dependencies = ["cheroot"]
@@ -58,3 +58,25 @@ exclude = '''
   | docs/conf.py
 )
 '''
+
+[tool.ruff]
+select = [
+  "C9",
+  "E",
+  "F",
+  "I",
+  "PLC",
+  "PLE",
+  "UP",
+  "W",
+]
+ignore = [
+  "E722",
+  "E731",
+  "F821",
+]
+line-length = 477
+show-source = true
+
+[tool.ruff.mccabe]
+max-complexity = 26

--- a/web/application.py
+++ b/web/application.py
@@ -13,9 +13,8 @@ from inspect import isclass
 from io import BytesIO
 from urllib.parse import unquote, urlencode, urlparse
 
-from . import browser, httpserver, utils
+from . import browser, httpserver, utils, wsgi
 from . import webapi as web
-from . import wsgi
 from .debugerror import debugerror
 from .py3helpers import iteritems
 from .utils import lstrips


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including flake8, isort, pylint, and pyupgrade and is written in Rust for speed.