### PR TITLE
[FIXED] # UnicodeError while handling a bug #757

### DIFF
--- a/web/debugerror.py
+++ b/web/debugerror.py
@@ -355,7 +355,7 @@ def emailerrors(to_address, olderror, from_address=None):
             "your buggy site <%s>" % from_address,
             "the bugfixer <%s>" % to_address,
             "bug: %(error_name)s: %(error_value)s (%(path)s)" % locals(),
-            message,
+            message.encode('utf-8'),
             attachments=[dict(filename="bug.html", content=safestr(djangoerror()))],
         )
         return error


### PR DESCRIPTION
This error occurs when there is an attempt to encode a Unicode character that is not in the ASCII range (i.e., outside the range of 0 to 127) using the ASCII codec. The character in question in your case is '\u2019', which is the right single quotation mark.

Encode the message using a Unicode encoding that supports all characters, such as UTF-8. You can do this by changing the encoding parameter of the encode() method to 'utf-8'