### PR TITLE
Replace cgi.FieldStorage functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cheroot>=6.0.0
+multipart==0.2.4

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -325,14 +325,19 @@ class ApplicationTest(unittest.TestCase):
         app = web.application(urls, locals())
 
         # 1x1 px red PNG.
-        image_data = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x0bIDAT\x08\xd7c\xf8\xff\xff?\x00\x05\xfe\x02\xfe\xdc\xccY\xe7\x00\x00\x00\x00IEND\xaeB`\x82'
-        data = b'--boundary\r\nContent-Disposition: form-data; name="x"\r\n\r\nfoo\r\n--boundary\r\nContent-Disposition: form-data; name="file"; filename="a.png"\r\nContent-Type: image/png\r\n\r\n' + image_data + b'\r\n--boundary--\r\n'
+        image_data = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x0bIDAT\x08\xd7c\xf8\xff\xff?\x00\x05\xfe\x02\xfe\xdc\xccY\xe7\x00\x00\x00\x00IEND\xaeB`\x82"
+        data = (
+            b'--boundary\r\nContent-Disposition: form-data; name="x"\r\n\r\nfoo\r\n--boundary\r\nContent-Disposition: form-data; name="file"; filename="a.png"\r\nContent-Type: image/png\r\n\r\n'
+            + image_data
+            + b"\r\n--boundary--\r\n"
+        )
         headers = {"Content-Type": "multipart/form-data; boundary=boundary"}
         response = app.request("/multipart", method="POST", data=data, headers=headers)
 
-        expected = Storage({'status': '200 OK', 'headers': {}, 'header_items': [], 'data': image_data})
+        expected = Storage(
+            {"status": "200 OK", "headers": {}, "header_items": [], "data": image_data}
+        )
         self.assertEqual(response, expected)
-
 
     def test1000PlusCharsInFieldInMultipartPOST(self):
         urls = ("(/.*)", "OneThousand")
@@ -342,8 +347,10 @@ class ApplicationTest(unittest.TestCase):
                 if path == "/multipart":
                     i = web.input(file={})
                     large_field = i.large_field
-                    file_contents = i.file.value.decode("utf-8")  # Make serializable to facilitate testing.
-                    resp = {'large_field': large_field, 'file_contents': file_contents}
+                    file_contents = i.file.value.decode(
+                        "utf-8"
+                    )  # Make serializable to facilitate testing.
+                    resp = {"large_field": large_field, "file_contents": file_contents}
                     return json.dumps(resp)
 
         app = web.application(urls, locals())
@@ -353,9 +360,8 @@ class ApplicationTest(unittest.TestCase):
         response = app.request("/multipart", method="POST", data=data, headers=headers)
 
         data = json.loads(response.data)
-        self.assertEqual(data.get('large_field'), "a"*1001)
-        self.assertEqual(data.get('file_contents'), 'a')
-
+        self.assertEqual(data.get("large_field"), "a" * 1001)
+        self.assertEqual(data.get("file_contents"), "a")
 
     def testCustomNotFound(self):
         urls_a = ("/", "a")

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -7,7 +7,6 @@ import time
 import unittest
 
 import web
-
 from web.utils import Storage
 
 try:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -354,9 +354,11 @@ class ApplicationTest(unittest.TestCase):
 
         app = web.application(urls, locals())
 
-        # Test for when the `name` field is identical (e.g. each file has `name="file"`)
+        # Test for when same `name` fields are identical (e.g. each file has
+        # `name="file"`, or `name=y" appears twice`)
         data = """--boundary\r\nContent-Disposition: form-data; name="x"\r\n\r\nfoo
 --boundary\r\nContent-Disposition: form-data; name="y"\r\n\r\nbar
+--boundary\r\nContent-Disposition: form-data; name="y"\r\n\r\nbaz
 --boundary\r\nContent-Disposition: form-data; name="file"; filename="a.txt"\r\nContent-Type: text/plain\r\n\r\na
 --boundary\r\nContent-Disposition: form-data; name="file"; filename="b.txt"\r\nContent-Type: text/plain\r\n\r\nb
 --boundary\r\nContent-Disposition: form-data; name="file"; filename="c.txt"\r\nContent-Type: text/plain\r\n\r\nc
@@ -366,7 +368,7 @@ class ApplicationTest(unittest.TestCase):
 
         expected = web.storage(
             {
-                "y": "bar",
+                "y": ["bar", "baz"],
                 "x": "foo",
                 "file": [
                     {"name": "file", "filename": "a.txt", "value": "a"},

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -29,9 +29,7 @@ def requires_module(name):
                 pass
 
             print(
-                "skipping all tests from {} as {} module is not found".format(
-                    cls.__name__, name
-                )
+                f"skipping all tests from {cls.__name__} as {name} module is not found"
             )
             return Foo
 

--- a/web/application.py
+++ b/web/application.py
@@ -244,7 +244,9 @@ class application:
             else:
                 q = data
 
-            env["wsgi.input"] = BytesIO(q.encode("utf-8")) if isinstance(q, str) else BytesIO(q)
+            env["wsgi.input"] = (
+                BytesIO(q.encode("utf-8")) if isinstance(q, str) else BytesIO(q)
+            )
             # if not env.get('CONTENT_TYPE', '').lower().startswith('multipart/') and 'CONTENT_LENGTH' not in env:
             if "CONTENT_LENGTH" not in env:
                 env["CONTENT_LENGTH"] = len(q)

--- a/web/application.py
+++ b/web/application.py
@@ -244,7 +244,7 @@ class application:
             else:
                 q = data
 
-            env["wsgi.input"] = BytesIO(q.encode("utf-8"))
+            env["wsgi.input"] = BytesIO(q.encode("utf-8")) if isinstance(q, str) else BytesIO(q)
             # if not env.get('CONTENT_TYPE', '').lower().startswith('multipart/') and 'CONTENT_LENGTH' not in env:
             if "CONTENT_LENGTH" not in env:
                 env["CONTENT_LENGTH"] = len(q)

--- a/web/form.py
+++ b/web/form.py
@@ -69,9 +69,7 @@ class Form:
                     html
                 )
             else:
-                out += '    <tr><th><label for="{}">{}</label></th><td>{}</td></tr>\n'.format(
-                    net.websafe(i.id), net.websafe(i.description), html
-                )
+                out += f'    <tr><th><label for="{net.websafe(i.id)}">{net.websafe(i.description)}</label></th><td>{html}</td></tr>\n'
         out += "</table>"
         return out
 
@@ -81,9 +79,7 @@ class Form:
         for i in self.inputs:
             if not i.is_hidden():
                 out.append(
-                    '<label for="{}">{}</label>'.format(
-                        net.websafe(i.id), net.websafe(i.description)
-                    )
+                    f'<label for="{net.websafe(i.id)}">{net.websafe(i.description)}</label>'
                 )
             out.append(i.pre)
             out.append(i.render())
@@ -344,10 +340,9 @@ class Dropdown(Input):
             select_p = ' selected="selected"'
         else:
             select_p = ""
-        return indent + '<option{} value="{}">{}</option>\n'.format(
-            select_p,
-            net.websafe(value),
-            net.websafe(desc),
+        return (
+            indent
+            + f'<option{select_p} value="{net.websafe(value)}">{net.websafe(desc)}</option>\n'
         )
 
 

--- a/web/template.py
+++ b/web/template.py
@@ -1017,13 +1017,7 @@ class Template(BaseTemplate):
             compiled_code = compile(code, filename, "exec")
         except SyntaxError as err:
             # display template line that caused the error along with the traceback.
-            err.msg += (
-                "\n\nTemplate traceback:\n    File {}, line {}\n        {}".format(
-                    repr(err.filename),
-                    err.lineno,
-                    get_source_line(err.filename, err.lineno - 1),
-                )
-            )
+            err.msg += f"\n\nTemplate traceback:\n    File {repr(err.filename)}, line {err.lineno}\n        {get_source_line(err.filename, err.lineno - 1)}"
 
             raise
 

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -452,26 +452,26 @@ def custom_parse_form_data(*args: str | bool, **kwargs: str | bool) -> tuple[mul
     return forms, files
 
 
+def preserve_fieldstorage_get_output_format(data: dict[str, Any]) -> dict[str, str | list[str]]:
+    """
+    Ensure output matches Python's cgi.FieldStorage handling for
+    query parameters.
+
+    >>> preserve_fieldstorage_get_output_format({'x': ['2'], 'y': ['1', '2']})
+    {'x': '2', 'y': ['1', '2']}
+    """
+    data_copy = data.copy()
+
+    for k, v in data_copy.items():
+        if len(v) == 1 and isinstance(v[0], (int, str)):
+            data_copy[k] = v[0]
+
+    return data_copy
+
+
 def rawinput(method: str | None = None) -> storage:
     """Returns storage object with GET or POST arguments."""
     method = method or "both"
-
-    def preserve_fieldstorage_get_output_format(data: dict[str, Any]) -> dict[str, str | list[str]]:
-        """
-        Ensure output matches Python's cgi.FieldStorage handling for
-        query parameters.
-
-        >>> preserve_fieldstorage_get_output_format({'x': ['2'], 'y': ['1', '2']})
-        {'x': '2', 'y': ['1', '2']}
-        """
-        data_copy = data.copy()
-
-        for k, v in data_copy.items():
-            if len(v) == 1 and isinstance(v[0], (int, str)):
-                data_copy[k] = v[0]
-
-        return data_copy
-
     env = ctx.env.copy()
     post_req = get_req = {}
 

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -8,8 +8,7 @@ import pprint
 import sys
 from http.cookies import CookieError, Morsel, SimpleCookie
 from typing import Any
-from urllib.parse import quote, unquote, urljoin
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, quote, unquote, urljoin
 
 import multipart
 

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -426,6 +426,7 @@ class MultipartPartWrapper:
             i = web.input(file={})
             name, filename, value = i.file.name, i.file.filename, i.file.value
     """
+
     def __init__(self, part: multipart.MultipartPart) -> None:
         self._part = part
 
@@ -440,7 +441,9 @@ class MultipartPartWrapper:
         return getattr(self._part, name)
 
 
-def custom_parse_form_data(*args: str | bool, **kwargs: str | bool) -> tuple[multipart.MultiDict, multipart.MultiDict]:
+def custom_parse_form_data(
+    *args: str | bool, **kwargs: str | bool
+) -> tuple[multipart.MultiDict, multipart.MultiDict]:
     """
     The same as multipart.parse_form_data, but always executes
     MultipartPartWrapper for backwards compatibility with cgi.FieldStorage.
@@ -452,7 +455,9 @@ def custom_parse_form_data(*args: str | bool, **kwargs: str | bool) -> tuple[mul
     return forms, files
 
 
-def preserve_fieldstorage_get_output_format(data: dict[str, Any]) -> dict[str, str | list[str]]:
+def preserve_fieldstorage_get_output_format(
+    data: dict[str, Any]
+) -> dict[str, str | list[str]]:
     """
     Ensure output matches Python's cgi.FieldStorage handling for
     query parameters.
@@ -477,7 +482,6 @@ def rawinput(method: str | None = None) -> storage:
 
     if method.lower() in ["both", "post", "put", "patch"]:
         if env["REQUEST_METHOD"] in ["POST", "PUT", "PATCH"]:
-
             if env.get("CONTENT_TYPE", "").lower().startswith("multipart/"):
                 # since wsgi.input is directly passed to cgi.FieldStorage,
                 # it can not be called multiple times. Saving the FieldStorage
@@ -499,7 +503,7 @@ def rawinput(method: str | None = None) -> storage:
 
     if method.lower() in ["both", "get"]:
         env["REQUEST_METHOD"] = "GET"
-        get_req = parse_qs(env.get('QUERY_STRING', ''), keep_blank_values=True)
+        get_req = parse_qs(env.get("QUERY_STRING", ""), keep_blank_values=True)
         get_req = preserve_fieldstorage_get_output_format(get_req)
 
     return storage(dictadd(get_req, post_req))

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -426,7 +426,7 @@ def rawinput(method=None):
 
     def dictify(fs):
         # hack to make web.input work with enctype='text/plain.
-        if fs.list is None:
+        if hasattr(fs, "list") and fs.list is None:
             fs.list = []
 
         return {k: fs[k] for k in fs}
@@ -461,11 +461,8 @@ def rawinput(method=None):
                     a = cgiFieldStorage(fp=fp, environ=e, keep_blank_values=1)
                     ctx._fieldstorage = a
             else:
-                d = data()
-                if isinstance(d, str):
-                    d = d.encode("utf-8")
-                fp = BytesIO(d)
-                a = cgiFieldStorage(fp=fp, environ=e, keep_blank_values=1)
+                d = data().decode("utf-8")
+                a = parse_qs(d, keep_blank_values=True)
             a = dictify(a)
 
     if method.lower() in ["both", "get"]:

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -383,23 +383,6 @@ def InternalError(message=None):
 internalerror = InternalError
 
 
-# class cgiFieldStorage(cgi.FieldStorage):
-#     """
-#     Subclass cgi.FieldStorage, as read_binary expects fp to return
-#     bytes. If the headers do not contain a content-disposition with a
-#     filename, cgi.FieldStorage's make_file will create a TemporaryFile
-#     with `w+` flags. The write to that temporary file will fail, due
-#     to incorrect encoding in Python 3.
-#     """
-
-#     def make_file(self, binary=None):
-#         """
-#         For backwards compatibility with Python 2, make_file accepted
-#         a binary flag. This was unused, and removed in Python 3.
-#         """
-#         return tempfile.TemporaryFile("wb+")
-
-
 def header(hdr, value, unique=False):
     """
     Adds the header `hdr: value` with the response.

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -448,15 +448,7 @@ def rawinput(method: str | None = None) -> storage:
         b = parse_qs(e.get('QUERY_STRING', ''), keep_blank_values=True)
         b = preserve_fieldstorage_get_output_format(b)
 
-    def process_fieldstorage(fs):
-        if isinstance(fs, list):
-            return [process_fieldstorage(x) for x in fs]
-        elif hasattr(fs, "filename") and fs.filename is None:
-            return fs.value
-        else:
-            return fs
-
-    return storage([(k, process_fieldstorage(v)) for k, v in dictadd(b, a).items()])
+    return storage(dictadd(get_req, post_req))
 
 
 def input(*requireds, **defaults):


### PR DESCRIPTION
Closes #732:
- #732

Closes #705:
- #705

This replaces `cgi.FieldStorage` with `urllib.parse.parse_qs` and `multipart`, as suggested by [PEP-0594](https://peps.python.org/pep-0594/#cgi).

Because every `GET` `POST`, and `PUT` goes through this code (I think), it needs more thorough testing than I have given it, largely because I was just testing with parts of Open Library. My hope is that this PR will serve as a starting point, if not quite the destination, for replacing the deprecated `cgi.FieldStorage`.

Some things of note
-------------------
- For backwards compatibility with type hints, I've used `from __future__ import annotations`, but this only goes back to current versions of Python 3.7 I think, with the Python 3.10+ type hints I am using; I realize these type hints may need to go for the sake of compatibility.
- This _seems_ to address the 1000 character limits for fields mentioned in #705; I have attempted to add a test for this.
- This should preserve `cgi.FieldStorage`'s behavior when attaching multiple files, and I have added tests to help verify this.
- This adds [multipart](https://github.com/defnull/multipart) as a dependency. `multipart` is the suggested replacement per [PEP-0594](https://peps.python.org/pep-0594/#cgi).
- By default, following `multiparse.parse_form_data`, parsing errors are ignored unless `strict=True` is passed through the parser. I have `strict=True` for now to help facilitate testing, but if this PR is accepted, perhaps this should be toggled back to `False` to keep it in line with the behavior of `multiparse`.

Technical explanation
---------------------
I've tried to preserve the functionality of `cgi.FieldStorage` that I know is in use, but this does not preserve every method on `FieldStorage` and `MiniFieldStorage` objects. In particular, I've tried to ensure the following continues to work as it always did:
```python
    class ImageUpload:
        def POST(self, path):
            i = web.input(file={})
            name, filename, value = i.file.name, i.file.filename, i.file.value
```

With `FieldStorage` objects, calling `.value` on them would give the raw value, such as the raw bytes for an image. However, with `MultipartPart` objects, the `.value` method attempts to decode the raw value, and this won't work with raw bytes, such as images.

To address that, the class `MultipartPartWrapper` intercepts calls to the `.value` method and replaces them with a call to the `.raw` method. All other calls pass through to the original object. I had tried to rebind `.value` to `.raw`, but `MultipartPart` seems to lack a setter:
```
  File "/home/scott/code/webpy/web/webapi.py", line 457, in preserve_value_method_as_raw                                                      
    data['file'].value = file.raw                                                                                                             
    ^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                      
AttributeError: property 'value' of 'MultipartPart' object has no setter
``` 

`custom_parse_form_data` exists to guarantee this wrapper is always in place so that calls to `.value` will always behave as expected.

Additionally, the `try`/`except` block for `custom_parse_form_data` helps the output match that of `cgi.FieldStorage`. `cgi.FieldStorage` would simply return an empty `FieldStorage` object with empty input, but `multipart.MultipartParser` raises an `IndexError` in this situation, as it attempts to access index 0 for the (empty) input. The `try`/`except` approach may be a bit ham-fisted, but it seems to work.

Testing
-------
This needs much more testing. So far:
- the web.py tests (should..) pass;
- the Open Library code base tests pass with this PR; and
- it's possible to upload a cover on Open Library via the web interface, which uses a multipart POST.

@cclauss 