### PR TITLE
Replace deprecated cgi module with multipart module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ python3 setup.py install
 
 Note:
 * `0.5x` (e.g. 0.50, 0.51) are our last releases which support Python 2.
-* `0.6x` (e.g. 0.60, 0.61, 0.62) are our last releases which support Python >= 3.5.
+* `0.6x` (e.g. 0.60, 0.61, 0.62) are our releases which support Python >= 3.5.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cheroot>=6.0.0
+multipart>=0.2.4

--- a/web/session.py
+++ b/web/session.py
@@ -286,7 +286,7 @@ class DiskStore(Store):
         path = self._get_path(key)
         pickled = self.encode(value)
         try:
-            tname = path + "." + threading.current_thread().getName()
+            tname = path + "." + threading.current_thread().name
             f = open(tname, "wb")
             try:
                 f.write(pickled)

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -3,12 +3,13 @@ Web API (wrapper around WSGI)
 (from web.py)
 """
 
-import multipart
 import pprint
 import sys
 import urllib
 from http.cookies import CookieError, Morsel, SimpleCookie
 from urllib.parse import quote, unquote, urljoin
+
+import multipart
 
 from .utils import dictadd, intget, safestr, storage, storify, threadeddict
 
@@ -420,7 +421,9 @@ def rawinput(method=None):
                 # since wsgi.input is directly passed to multipart,
                 # it can not be called multiple times. Saving the result
                 # object in ctx to allow calling web.input multiple times.
-                a = ctx.get("_fieldstorage")  # TODO: Rename? is this visible anywhere else?
+                a = ctx.get(
+                    "_fieldstorage"
+                )  # TODO: Rename? is this visible anywhere else?
                 if not a:
                     # This returns two dicts, forms & files.
                     forms, a = multipart.parse_form_data(environ=env)
@@ -438,7 +441,9 @@ def rawinput(method=None):
     def process_values(values):
         if isinstance(values, list):
             return [process_values(x) for x in values]
-        elif hasattr(values, "filename") and values.filename is None:  # FIXME this probably needs to be improved
+        elif (
+            hasattr(values, "filename") and values.filename is None
+        ):  # FIXME this probably needs to be improved
             return values.value
         else:
             return values

--- a/web/webapi.py
+++ b/web/webapi.py
@@ -3,12 +3,11 @@ Web API (wrapper around WSGI)
 (from web.py)
 """
 
-import cgi
+import multipart
 import pprint
 import sys
-import tempfile
+import urllib
 from http.cookies import CookieError, Morsel, SimpleCookie
-from io import BytesIO
 from urllib.parse import quote, unquote, urljoin
 
 from .utils import dictadd, intget, safestr, storage, storify, threadeddict
@@ -382,23 +381,6 @@ def InternalError(message=None):
 internalerror = InternalError
 
 
-class cgiFieldStorage(cgi.FieldStorage):
-    """
-    Subclass cgi.FieldStorage, as read_binary expects fp to return
-    bytes. If the headers do not contain a content-disposition with a
-    filename, cgi.FieldStorage's make_file will create a TemporaryFile
-    with `w+` flags. The write to that temporary file will fail, due
-    to incorrect encoding in Python 3.
-    """
-
-    def make_file(self, binary=None):
-        """
-        For backwards compatibility with Python 2, make_file accepted
-        a binary flag. This was unused, and removed in Python 3.
-        """
-        return tempfile.TemporaryFile("wb+")
-
-
 def header(hdr, value, unique=False):
     """
     Adds the header `hdr: value` with the response.
@@ -423,47 +405,45 @@ def rawinput(method=None):
     method = method or "both"
 
     def dictify(fs):
-        # hack to make web.input work with enctype='text/plain.
-        if fs.list is None:
-            fs.list = []
-
         return {k: fs[k] for k in fs}
 
-    e = ctx.env.copy()
+    env = ctx.env.copy()
     a = b = {}
 
+    # This is required by the multipart module and not set up by the tests, so add the default value if missing
+    if "CONTENT_TYPE" not in env:
+        env["CONTENT_TYPE"] = "application/x-www-form-urlencoded"
+
     if method.lower() in ["both", "post", "put", "patch"]:
-        if e["REQUEST_METHOD"] in ["POST", "PUT", "PATCH"]:
-            if e.get("CONTENT_TYPE", "").lower().startswith("multipart/"):
-                # since wsgi.input is directly passed to cgi.FieldStorage,
-                # it can not be called multiple times. Saving the FieldStorage
+        if env["REQUEST_METHOD"] in ["POST", "PUT", "PATCH"]:
+            if env.get("CONTENT_TYPE", "").lower().startswith("multipart/"):
+                # since wsgi.input is directly passed to multipart,
+                # it can not be called multiple times. Saving the result
                 # object in ctx to allow calling web.input multiple times.
-                a = ctx.get("_fieldstorage")
+                a = ctx.get("_fieldstorage")  # TODO: Rename? is this visible anywhere else?
                 if not a:
-                    fp = e["wsgi.input"]
-                    a = cgiFieldStorage(fp=fp, environ=e, keep_blank_values=1)
+                    # This returns two dicts, forms & files.
+                    forms, a = multipart.parse_form_data(environ=env)
                     ctx._fieldstorage = a
             else:
-                d = data()
-                if isinstance(d, str):
-                    d = d.encode("utf-8")
-                fp = BytesIO(d)
-                a = cgiFieldStorage(fp=fp, environ=e, keep_blank_values=1)
+                # TODO: Can we safely ignore files here or should we merge them
+                # This returns two dicts: forms & files
+                a, files = multipart.parse_form_data(environ=env)
             a = dictify(a)
 
     if method.lower() in ["both", "get"]:
-        e["REQUEST_METHOD"] = "GET"
-        b = dictify(cgiFieldStorage(environ=e, keep_blank_values=1))
+        env["REQUEST_METHOD"] = "GET"
+        b = dict(urllib.parse.parse_qs(env["QUERY_STRING"], keep_blank_values=True))
 
-    def process_fieldstorage(fs):
-        if isinstance(fs, list):
-            return [process_fieldstorage(x) for x in fs]
-        elif fs.filename is None:
-            return fs.value
+    def process_values(values):
+        if isinstance(values, list):
+            return [process_values(x) for x in values]
+        elif hasattr(values, "filename") and values.filename is None:  # FIXME this probably needs to be improved
+            return values.value
         else:
-            return fs
+            return values
 
-    return storage([(k, process_fieldstorage(v)) for k, v in dictadd(b, a).items()])
+    return storage([(k, process_values(v)) for k, v in dictadd(b, a).items()])
 
 
 def input(*requireds, **defaults):


### PR DESCRIPTION
May fix #732 

I took a cut at replacing the deprecated cgi module. The tests are green, but I don't really trust their coverage, so someone (not me) should give it a fair bit of testing.

I also removed a usage of the deprecated Thread.getName() function as a completely unrelated bonus commit.