### PR TITLE
ruff --select=UP032 --fix .

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -29,9 +29,7 @@ def requires_module(name):
                 pass
 
             print(
-                "skipping all tests from {} as {} module is not found".format(
-                    cls.__name__, name
-                )
+                f"skipping all tests from {cls.__name__} as {name} module is not found"
             )
             return Foo
 

--- a/web/form.py
+++ b/web/form.py
@@ -69,9 +69,7 @@ class Form:
                     html
                 )
             else:
-                out += '    <tr><th><label for="{}">{}</label></th><td>{}</td></tr>\n'.format(
-                    net.websafe(i.id), net.websafe(i.description), html
-                )
+                out += f'    <tr><th><label for="{net.websafe(i.id)}">{net.websafe(i.description)}</label></th><td>{html}</td></tr>\n'
         out += "</table>"
         return out
 
@@ -81,9 +79,7 @@ class Form:
         for i in self.inputs:
             if not i.is_hidden():
                 out.append(
-                    '<label for="{}">{}</label>'.format(
-                        net.websafe(i.id), net.websafe(i.description)
-                    )
+                    f'<label for="{net.websafe(i.id)}">{net.websafe(i.description)}</label>'
                 )
             out.append(i.pre)
             out.append(i.render())
@@ -344,10 +340,9 @@ class Dropdown(Input):
             select_p = ' selected="selected"'
         else:
             select_p = ""
-        return indent + '<option{} value="{}">{}</option>\n'.format(
-            select_p,
-            net.websafe(value),
-            net.websafe(desc),
+        return (
+            indent
+            + f'<option{select_p} value="{net.websafe(value)}">{net.websafe(desc)}</option>\n'
         )
 
 

--- a/web/template.py
+++ b/web/template.py
@@ -1017,13 +1017,7 @@ class Template(BaseTemplate):
             compiled_code = compile(code, filename, "exec")
         except SyntaxError as err:
             # display template line that caused the error along with the traceback.
-            err.msg += (
-                "\n\nTemplate traceback:\n    File {}, line {}\n        {}".format(
-                    repr(err.filename),
-                    err.lineno,
-                    get_source_line(err.filename, err.lineno - 1),
-                )
-            )
+            err.msg += f"\n\nTemplate traceback:\n    File {repr(err.filename)}, line {err.lineno}\n        {get_source_line(err.filename, err.lineno - 1)}"
 
             raise
 


### PR DESCRIPTION
Fixes #772

% `ruff --select=UP032 --fix .`
```
Found 5 errors (5 fixed, 0 remaining).
```
% `ruff rule UP032`
# f-string (UP032)

Derived from the **pyupgrade** linter.

Autofix is always available.

## What it does
Checks for `str#format` calls that can be replaced with f-strings.

## Why is this bad?
f-strings are more readable and generally preferred over `str#format` calls.

## Example
```python
"{}".format(foo)
```

Use instead:
```python
f"{foo}"
```

## References
- [Python documentation: f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings)
- [Python f-string benchmarks](https://www.scivision.dev/python-f-string-speed)