### PR TITLE
web.py release v0.70

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
     - id: validate-pyproject
 
 -   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.1.0
+    rev: 1.2.0
     hooks:
     - id: pyproject-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         - tomli
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.0.292
     hooks:
     - id: ruff
       # args: [--fix, --exit-non-zero-on-fix]

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,11 @@
 # web.py changelog
 
+## 2023-10-02 0.70
+
+* Remove the cgi module which will be removed in Python 3.13 #773
+* Add support for current versions of CPython
+* Upgrade testing and linting tools
+
 ## 2020-11-09 0.62
 
 * Fixed: application.load() assumes ctx.path will be a latin1 string #687

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
+[![pypi](https://img.shields.io/pypi/v/web.py)](https://pypi.org/project/web.py/)
+[![python versions](https://img.shields.io/pypi/pyversions/web.py)](https://pypi.org/project/web.py/)
+[![build status](https://github.com/webpy/webpy/actions/workflows/lint_python.yml/badge.svg)](https://github.com/webpy/webpy/actions/workflows/lint_python.yml)
+
 web.py is a Python web framework that is as simple as it is powerful.
 
 Visit http://webpy.org for more information.
 
-[![build status](https://github.com/webpy/webpy/actions/workflows/lint_python.yml/badge.svg)](https://github.com/webpy/webpy/actions/workflows/lint_python.yml)
 
 This release supports all currently supported versions of CPython: https://devguide.python.org/versions
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-[![pypi](https://img.shields.io/pypi/v/web.py)](https://pypi.org/project/web.py/)
-[![python versions](https://img.shields.io/pypi/pyversions/web.py)](https://pypi.org/project/web.py/)
+[![pypi](https://img.shields.io/pypi/v/web.py)](https://pypi.org/project/web.py)
+[![python versions](https://img.shields.io/pypi/pyversions/web.py)](https://devguide.python.org/versions)
 [![build status](https://github.com/webpy/webpy/actions/workflows/lint_python.yml/badge.svg)](https://github.com/webpy/webpy/actions/workflows/lint_python.yml)
 
 web.py is a Python web framework that is as simple as it is powerful.
 
 Visit http://webpy.org for more information.
 
-
-This release supports all currently supported versions of CPython: https://devguide.python.org/versions
-
-To install it, please run:
+To install web.py, please run:
 ```
 python3 -m pip install web.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ select = [
   "I",
   "PLC",
   "PLE",
+  "PLR",
   "UP",
   "W",
 ]
@@ -75,7 +76,7 @@ ignore = [
   "E722",
   "E731",
   "F821",
-  "PLC1901",
+  "PLR5501",
 ]
 line-length = 477
 show-source = true
@@ -83,6 +84,13 @@ target-version = "py38"
 
 [tool.ruff.mccabe]
 max-complexity = 26
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["int", "str"]
+max-args = 9  # default is 5
+max-branches = 17  # default is 12
+max-returns = 8  # default is 6
+max-statements = 51  # default is 50
 
 [tool.codespell]
 ignore-words-list = "asend,gae"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -395,7 +395,7 @@ class ApplicationTest(unittest.TestCase):
         self.assertEqual(f("/?x=2"), b"/?x=1")
 
         p = f("/?y=1&y=2&x=2")
-        self.assertTrue(p == b"/?y=1&y=2&x=1" or p == b"/?x=1&y=1&y=2")
+        self.assertTrue(p in {b"/?y=1&y=2&x=1", b"/?x=1&y=1&y=2"})
 
     def test_setcookie(self):
         urls = ("/", "index")

--- a/tools/makedoc.py
+++ b/tools/makedoc.py
@@ -136,7 +136,7 @@ def recurse_over(ob, name, indent_level=0):
     argstr = ""
     if ts.endswith(("function", "method")):
         argstr = arg_string(ob)
-    elif ts == "classobj" or ts == "type":
+    elif ts in {"classobj", "type"}:
         if ts == "classobj":
             ts = "class"
         if hasattr(ob, "__init__"):

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -24,7 +24,7 @@ from .utils import *  # noqa: F401,F403
 from .webapi import *  # noqa: F401,F403
 from .wsgi import *  # noqa: F401,F403
 
-__version__ = "0.62"
+__version__ = "0.70"
 __author__ = [
     "Aaron Swartz <me@aaronsw.com>",
     "Anand Chitipothu <anandology@gmail.com>",

--- a/web/template.py
+++ b/web/template.py
@@ -303,7 +303,6 @@ class Parser:
                     t = next(tokens)
                     if t.value == end:
                         break
-            return
 
         parens = {"(": ")", "[": "]", "{": "}"}
 


### PR DESCRIPTION
To see `README.md` rendered, go to https://github.com/cclauss/webpy/tree/v0.70#readme  The badges will be automatically updated when the new version lands on PyPI.

Do you see other changes since the previous version that should be added to the changelog?
* https://github.com/webpy/webpy/pulls?q=is%3Apr+is%3Aclosed

Use [ruff's pylint refactor settings](https://docs.astral.sh/ruff/settings/#pylint) to set upper limits on code complexity.