### PR TITLE
Fix: enable Python 3.12 to parse templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,14 +83,13 @@ show-source = true
 target-version = "py38"
 
 [tool.ruff.mccabe]
-max-complexity = 26
+max-complexity = 20
 
 [tool.ruff.pylint]
 allow-magic-value-types = ["int", "str"]
 max-args = 9  # default is 5
 max-branches = 17  # default is 12
 max-returns = 8  # default is 6
-max-statements = 51  # default is 50
 
 [tool.codespell]
 ignore-words-list = "asend,gae"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cheroot>=6.0.0
+more_itertools>=2.6
 multipart>=0.2.4

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -4,6 +4,13 @@ import web
 from web.template import ExpressionNode, Parser, SecurityError, Template
 
 
+class TestItem:
+    __test__ = False  # silence collection warning from test framework
+
+    def __init__(self):
+        self.id = 12345
+
+
 class _TestResult:
     def __init__(self, t):
         self.t = t
@@ -47,6 +54,16 @@ class TemplateTest(unittest.TestCase):
         template = 'a="$foo" <p>'
         f = t(template, globals={"foo": "bar"})
         assert repr(f()) == "'a=\"bar\" <p>\\n'"
+
+    def test_accessor(self):
+        template = 'a="$foo.id"<p>'
+        f = t(template, globals={"foo": TestItem()})
+        assert repr(f()) == "'a=\"12345\"<p>\\n'"
+
+    def test_href(self):
+        template = '<a href="/del/$item.id">Delete</a>'
+        f = t(template, globals={"item": TestItem()})
+        assert repr(f()) == "'<a href=\"/del/12345\">Delete</a>\\n'"
 
 
 class TestParser(unittest.TestCase):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,7 +1,7 @@
 import unittest
 
 import web
-from web.template import SecurityError, Template
+from web.template import ExpressionNode, Parser, SecurityError, Template
 
 
 class _TestResult:
@@ -42,6 +42,51 @@ class TemplateTest(unittest.TestCase):
         tpl = "$print('blah')"
         f = t(tpl, globals={"print": lambda x: x})
         assert repr(f()) == "'blah\\n'"
+
+    def test_quotes(self):
+        template = 'a="$foo" <p>'
+        f = t(template, globals={"foo": "bar"})
+        assert repr(f()) == "'a=\"bar\" <p>\\n'"
+
+
+class TestParser(unittest.TestCase):
+    """
+    Test the Parser.
+
+    Tests functions from the Parser class as if the following template were loaded:
+
+    test_template = '''$def with (back, docs)
+    $var title: Index
+    <p><a href="$back">&larr; Back to Index</a></p>
+    <ul>
+    $for path, title in docs:
+        <li><a href="$path">$title</a></li>
+    </ul>
+    '''
+    """
+
+    def test_read_expr(self) -> None:
+        """
+        Test Parser.read_expr() with the `text` values it would get from
+        `Parser.read_node(), if processing `test_template`.
+        """
+        got = Parser().read_expr('back">&larr; Back to Index</a></p>\n')
+        expression_node = got[0]
+        assert isinstance(expression_node, ExpressionNode)
+        assert repr(expression_node) == "$back"
+        assert got[1] == '">&larr; Back to Index</a></p>\n'
+
+        got = Parser().read_expr('path">$title</a></li>\n')
+        expression_node = got[0]
+        assert isinstance(expression_node, ExpressionNode)
+        assert repr(expression_node) == "$path"
+        assert got[1] == '">$title</a></li>\n'
+
+        got = Parser().read_expr("title</a></li>\n")
+        expression_node = got[0]
+        assert isinstance(expression_node, ExpressionNode)
+        assert repr(expression_node) == "$title"
+        assert got[1] == "</a></li>\n"
 
 
 class TestRender:

--- a/web/browser.py
+++ b/web/browser.py
@@ -1,6 +1,7 @@
 """Browser to test web applications.
 (from web.py)
 """
+
 import os
 import webbrowser
 from http.cookiejar import CookieJar
@@ -46,7 +47,7 @@ class Browser:
 
     def build_opener(self):
         """Builds the opener using (urllib2/urllib.request).build_opener.
-        Subclasses can override this function to prodive custom openers.
+        Subclasses can override this function to provide custom openers.
         """
         return urllib_build_opener()
 

--- a/web/contrib/template.py
+++ b/web/contrib/template.py
@@ -1,6 +1,7 @@
 """
 Interface to various templating engines.
 """
+
 import os.path
 
 __all__ = ["render_cheetah", "render_genshi", "render_mako", "cache"]

--- a/web/db.py
+++ b/web/db.py
@@ -2,6 +2,7 @@
 Database API
 (part of web.py)
 """
+
 import ast
 import datetime
 import os

--- a/web/net.py
+++ b/web/net.py
@@ -3,7 +3,6 @@ Network Utilities
 (from web.py)
 """
 
-
 import datetime
 import re
 import socket

--- a/web/template.py
+++ b/web/template.py
@@ -335,17 +335,14 @@ class Parser:
             try:
                 yield from tokenize_text(text)
             except tokenize.TokenError as e:
-                if "unterminated string literal" in str(e):
-                    # Things like unterminated string literals or EOF in multi-line literals will raise exceptions.
-                    # Tokenize the error free portion, then return an error token with the rest of the text.
-                    error_pos = e.args[1][1] - 1
-                    fixed_text = text[0:error_pos]
-                    yield from itertools.chain(
-                        tokenize_text(fixed_text),
-                        error_token_generator(text, error_pos, len(text)),
-                    )
-                else:
-                    raise
+                # Things like unterminated string literals or EOF in multi-line literals will raise exceptions
+                # tokenize the error free portion, then return an error token with the rest of the text
+                error_pos = e.args[1][1] - 1
+                fixed_text = text[0:error_pos]
+                yield from itertools.chain(
+                    tokenize_text(fixed_text),
+                    error_token_generator(text, error_pos + 1, len(text)),
+                )
 
         def error_token_generator(text, start, end):
             yield storage(

--- a/web/template.py
+++ b/web/template.py
@@ -242,7 +242,7 @@ class Parser:
         line, text = splitline(text)
         return StatementNode(line.strip() + "\n"), text
 
-    def read_expr(self, text, escape=True):
+    def read_expr(self, text, escape=True):  # noqa: C901, PLR0915
         """Reads a python expression from the text and returns the expression and remaining text.
 
         expr -> simple_expr | paren_expr

--- a/web/test.py
+++ b/web/test.py
@@ -1,6 +1,7 @@
 """test utilities
 (part of web.py)
 """
+
 import doctest
 import sys
 import unittest


### PR DESCRIPTION
Closes #784.

This PR fixes the inability of `web.py` to parse templates on Python 3.12, and it does so by matching any unmatched `"` in a string.

In Python 3.12, changes to `tokenize.generate_tokens()` requires all quotes to be matched, and the `web.py` template parser hands unterminated strings to `tokenize.generate_tokens()` quite frequently.

This PR makes a tacit assumption that we should avoid rewriting the template parser if possible while also allowing `web.py` to parse templates on Python 3.12.

To that end, it handles every `TokenError` caused by unterminated string literals (i.e. unmatched `"` characters) by adding a `"` to the line where one is missing. Although this appears to work, I am aware that appending a `"` to each line that has an unmatched `"` is less than ideal. However, it seemed a very easy way to avoid rewriting the template parser. I am absolutely open to other approaches.

*IF* this approach looks as if it has legs, I can can look more into where that "extra" `"` goes, why it seems not to matter, and write some unit tests.

With regard to testing, I tested this with as many pages on Open Library that I could (via the local development environment), and it seems to work.

Edit: for the time being I added an exception to the upper limits on code complexity. If this solution looks worth pursuing, I can try to sort out the code complexity issue.