### PR TITLE
Fix: update deprecated sqlite3 datetime and timestamp adapters

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,37 @@
 import os
 import shutil
+import sqlite3
 import tempfile
 import threading
 import time
 import unittest
+from datetime import datetime
 
 import web
+
+
+def adapt_datetime_iso(date_time: datetime) -> str:
+    """
+    Convert a Python datetime.datetime into a timezone-naive ISO 8601 date string.
+
+    >>> adapt_datetime_iso(datetime(2023, 4, 5, 6, 7, 8, 9))
+    '2023-04-05T06:07:08.000009'
+    """
+    return date_time.isoformat()
+
+
+def convert_timestamp(time_stamp: bytes) -> datetime:
+    """
+    Convert an ISO 8601 formatted bytestring to a datetime.datetime object.
+
+    >>> convert_timestamp(b'2023-04-05T06:07:08.000009')
+    datetime.datetime(2023, 4, 5, 6, 7, 8, 9)
+    """
+    return datetime.strptime(time_stamp.decode("utf-8"), "%Y-%m-%dT%H:%M:%S.%f")
+
+
+sqlite3.register_adapter(datetime, adapt_datetime_iso)
+sqlite3.register_converter("timestamp", convert_timestamp)
 
 
 class SessionTest(unittest.TestCase):


### PR DESCRIPTION
Closes #783.

This PR updates the `datetime` and `timestamp` adapters for `sqlite3` in Python 3.12.

I leaned on the relevant [Open Library PR](https://github.com/internetarchive/openlibrary/pull/7827/files), however I put the code into the tests, rather than within `web.py`.

I made the changes to the tests as that's what use `sqlite3`, but perhaps they belong in `web/db.py`. For what it's worth, `web.py` doesn't currently import `sqlite3`.

Anyhow, please let me know if I should move where this code is.

Here's a before and after of running `pytest tests/test_session.py -s`:
Before:
```
INSERT INTO session (atime, data, session_id) VALUES ('2024-01-10T15:43:39.344341', 'gASVTQAAAAAAAAB9lCiMCnNlc3Npb25faWSUjCg4ODNmYjgwNGJmMGYzMWU5YWFmOTY5Zjk3ZDYz\nYTQ5NDNkZDM1ZmNilIwFY291bnSUSwGMAmlwlE51Lg==\n', '883fb804bf0f31e9aaf969f97d63a4943dd35fcb')
```

After:
```
INSERT INTO session (atime, data, session_id) VALUES ('2024-01-10T15:43:56.199466', 'gASVTQAAAAAAAAB9lCiMCnNlc3Npb25faWSUjChjOTc0NDgzZWNjNzdhODQ3YmY5NzZlMjBlYTkx\nYzc5OGQxOTdkZWY1lIwFY291bnSUSwGMAmlwlE51Lg==\n', 'c974483ecc77a847bf976e20ea91c798d197def5')
```

For more, see:
https://docs.python.org/3/library/sqlite3.html#default-adapters-and-converters-deprecated