### PR TITLE
Automate PyPI release on new tag push

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -42,7 +42,7 @@ jobs:
       - run: pip install black "codespell[toml]" pytest ruff
       - run: black --check .
       - run: codespell
-      - run: ruff --output-format=github .
+      - run: ruff check --output-format=github
 
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  pypi-publish:
+    if: startsWith(github.ref, 'refs/tags')
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/web.py-update
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Build
+      run: |
+        python -m pip install setuptools build wheel
+        python -m build .
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/web.py-update
+      url: https://pypi.org/p/web.py
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
     - name: Build
       run: |
         python -m pip install setuptools build wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: black
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell
       additional_dependencies:
@@ -20,11 +20,11 @@ repos:
       # args: [--fix, --exit-non-zero-on-fix]
 
 -   repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.16
+    rev: v0.23
     hooks:
     - id: validate-pyproject
 
 -   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.8.0
+    rev: v2.5.0
     hooks:
     - id: pyproject-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ exclude = '''
 '''
 
 [tool.ruff]
-select = [
+lint.select = [
   "C9",
   "E",
   "F",
@@ -72,7 +72,7 @@ select = [
   "UP",
   "W",
 ]
-ignore = [
+lint.ignore = [
   "E722",
   "E731",
   "F821",
@@ -80,13 +80,12 @@ ignore = [
   "UP031",
 ]
 line-length = 477
-show-source = true
 target-version = "py38"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 20
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 allow-magic-value-types = ["int", "str"]
 max-args = 9  # default is 5
 max-branches = 17  # default is 12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
   "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 ]
 
 [project]
-name = "web-py"
+name = "web.py-update"
 description = "web.py: makes web apps"
 readme = {file = "README.md", content-type = "text/plain"}
 license = {text = "Public domain"}
@@ -24,9 +24,7 @@ classifiers = [
 ]
 dynamic = [
   "version",
-]
-dependencies = [
-  "cheroot",
+  "dependencies",
 ]
 [project.urls]
 Homepage = "http://webpy.org/"
@@ -39,6 +37,7 @@ include-package-data = false
 
 [tool.setuptools.dynamic]
 version = {attr = "web.__version__"}
+dependencies = {file = ["requirements.txt"]}
 
 [tool.black]
 exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ requires = [
 ]
 
 [project]
-name = "web.py-update"
+name = "web-py"
 description = "web.py: makes web apps"
-readme = {file = "README.md", content-type = "text/plain"}
-license = {text = "Public domain"}
-maintainers = [{name = "Anand Chitipothu", email = "anandology@gmail.com"}]
-authors = [{name = "Aaron Swartz", email = "me@aaronsw.com"}]
+readme = { file = "README.md", content-type = "text/plain" }
+license = { text = "Public domain" }
+maintainers = [ { name = "Anand Chitipothu", email = "anandology@gmail.com" } ]
+authors = [ { name = "Aaron Swartz", email = "me@aaronsw.com" } ]
 requires-python = ">=3.8,<=3.13"
 classifiers = [
   "License :: Public Domain",
@@ -24,21 +24,20 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
-  "version",
   "dependencies",
+  "version",
 ]
-[project.urls]
-Homepage = "http://webpy.org/"
-Source = "https://github.com/webpy/webpy"
+urls.Homepage = "http://webpy.org/"
+urls.Source = "https://github.com/webpy/webpy"
 
 [tool.setuptools]
-packages = ["web", "web.contrib"]
-platforms = ["any"]
+packages = [ "web", "web.contrib" ]
+platforms = [ "any" ]
 include-package-data = false
 
 [tool.setuptools.dynamic]
-version = {attr = "web.__version__"}
-dependencies = {file = ["requirements.txt"]}
+version = { attr = "web.__version__" }
+dependencies = { file = [ "requirements.txt" ] }
 
 [tool.black]
 exclude = '''
@@ -61,6 +60,9 @@ exclude = '''
 '''
 
 [tool.ruff]
+target-version = "py39"
+
+line-length = 477
 lint.select = [
   "C9",
   "E",
@@ -79,18 +81,12 @@ lint.ignore = [
   "PLR5501",
   "UP031",
 ]
-line-length = 477
-target-version = "py38"
-
-[tool.ruff.lint.mccabe]
-max-complexity = 20
-
-[tool.ruff.lint.pylint]
-allow-magic-value-types = ["int", "str"]
-max-args = 9  # default is 5
-max-branches = 17  # default is 12
-max-returns = 8  # default is 6
+lint.mccabe.max-complexity = 20
+lint.pylint.allow-magic-value-types = [ "int", "str" ]
+lint.pylint.max-args = 9 # default is 5
+lint.pylint.max-branches = 17 # default is 12
+lint.pylint.max-returns = 8 # default is 6
 
 [tool.codespell]
 ignore-words-list = "asend,gae,notin"
-skip = ["./.*"]
+skip = [ "./.*" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,5 +92,5 @@ max-branches = 17  # default is 12
 max-returns = 8  # default is 6
 
 [tool.codespell]
-ignore-words-list = "asend,gae"
+ignore-words-list = "asend,gae,notin"
 skip = ["./.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = {file = "README.md", content-type = "text/plain"}
 license = {text = "Public domain"}
 maintainers = [{name = "Anand Chitipothu", email = "anandology@gmail.com"}]
 authors = [{name = "Aaron Swartz", email = "me@aaronsw.com"}]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<=3.13"
 classifiers = [
   "License :: Public Domain",
   "Programming Language :: Python",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,7 +37,7 @@ class TestStorify:
         assert utils.storify({}, a={}).a == {}
 
         result = utils.storify({"a": utils.storage(value=1)}, a={}).a
-        assert type(result) == utils.storage
+        assert type(result) is utils.storage
         assert result.value == 1
 
     def test_storify_with_a_binary_file_value(self):

--- a/tools/makedoc.py
+++ b/tools/makedoc.py
@@ -180,8 +180,8 @@ def recurse_over(ob, name, indent_level=0):
         members = [item for item in dir(ob) if not item.startswith("_")]
 
     if "im_class" not in members:
-        for name in members:
-            recurse_over(getattr(ob, name), name, indent_level + 1)
+        for member_name in members:
+            recurse_over(getattr(ob, member_name), member_name, indent_level + 1)
     if indent_level > 0:
         print(indent_end)
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -24,7 +24,7 @@ from .utils import *  # noqa: F401,F403
 from .webapi import *  # noqa: F401,F403
 from .wsgi import *  # noqa: F401,F403
 
-__version__ = "0.70"
+__version__ = "0.73"
 __author__ = [
     "Aaron Swartz <me@aaronsw.com>",
     "Anand Chitipothu <anandology@gmail.com>",

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -24,7 +24,7 @@ from .utils import *  # noqa: F401,F403
 from .webapi import *  # noqa: F401,F403
 from .wsgi import *  # noqa: F401,F403
 
-__version__ = "0.74"
+__version__ = "0.70"
 __author__ = [
     "Aaron Swartz <me@aaronsw.com>",
     "Anand Chitipothu <anandology@gmail.com>",

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -24,7 +24,7 @@ from .utils import *  # noqa: F401,F403
 from .webapi import *  # noqa: F401,F403
 from .wsgi import *  # noqa: F401,F403
 
-__version__ = "0.73"
+__version__ = "0.74"
 __author__ = [
     "Aaron Swartz <me@aaronsw.com>",
     "Anand Chitipothu <anandology@gmail.com>",


### PR DESCRIPTION
Automate the release of web.py to PyPI on tag push. @scottbarnes 

Also, reverts the name back to web.py (instead of web-py), for historical consistency.

Furthermore, the pyproject.toml didn't include a dynamic reference to the requirements.txt, so it was missing some dependencies on install; this was corrected.


Of course, when merging, correct the name `web.py-update` back to `web.py` in both `.github/workflows/release.yml` and `pyproject.toml`...  And, correct the `web/__init__.py` to contain the desired `__version__`.

You'll need to create a new Pending Publisher in the PyPI account's https://pypi.org/manage/account/publishing/, designating the Project Name web.py, Github Owner webpy and Repository webpy, and the workflow release.yml.  Then, re-push a tag for the version you want to release (eg. if you decide to change the master branch version to 0.71: `git tag 0.71; git push --tags`)

That should trigger the action and push the new release to PyPI.


Fixes #794
Fixes #798