### PR TITLE
Release web.py v0.75 to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint_python
+name: ci
 on:
   pull_request:
   push:
@@ -6,7 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint_python:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+      - uses: astral-sh/ruff-action@v3
+      - run: ruff format
+
+  test:
+    needs: lint
     runs-on: ubuntu-latest
 
     services:
@@ -39,10 +48,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - run: pip install black "codespell[toml]" pytest ruff
-      - run: black --check .
-      - run: codespell
-      - run: ruff check --output-format=github
 
       - name: "Install dependent Python modules for testing."
         run: pip install -r requirements.txt -r test_requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 # default_language_version:
-#     python: python3.7
+#     python: python3.13
 repos:
--   repo: https://github.com/python/black
-    rev: 24.4.2
-    hooks:
-    - id: black
-
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
@@ -14,10 +9,11 @@ repos:
         - tomli
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.2
+    rev: v0.8.6
     hooks:
     - id: ruff
       # args: [--fix, --exit-non-zero-on-fix]
+    - id: ruff-format
 
 -   repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,11 @@ readme = { file = "README.md", content-type = "text/plain" }
 license = { text = "Public domain" }
 maintainers = [ { name = "Anand Chitipothu", email = "anandology@gmail.com" } ]
 authors = [ { name = "Aaron Swartz", email = "me@aaronsw.com" } ]
-requires-python = ">=3.8,<=3.13"
+requires-python = ">=3.9,<3.14"
 classifiers = [
   "License :: Public Domain",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -61,8 +60,6 @@ exclude = '''
 
 [tool.ruff]
 target-version = "py39"
-
-line-length = 477
 lint.select = [
   "C9",
   "E",
@@ -75,6 +72,7 @@ lint.select = [
   "W",
 ]
 lint.ignore = [
+  "E501",
   "E722",
   "E731",
   "F821",

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -16,7 +16,7 @@ class WSGITest(unittest.TestCase):
 
         class uni:
             def GET(self):
-                return "\u0C05\u0C06"
+                return "\u0c05\u0c06"
 
         app = web.application(urls, locals())
 
@@ -27,7 +27,7 @@ class WSGITest(unittest.TestCase):
         b = web.browser.AppBrowser(app)
         r = b.open("/").read()
         s = r.decode("utf8")
-        self.assertEqual(s, "\u0C05\u0C06")
+        self.assertEqual(s, "\u0c05\u0c06")
 
         app.stop()
         thread.join()
@@ -68,7 +68,7 @@ class WSGITest(unittest.TestCase):
         b = web.browser.AppBrowser(app)
         r = b.open("/%E2%84%A6")
         s = unquote(r.read())
-        self.assertEqual(s, b"\xE2\x84\xA6")
+        self.assertEqual(s, b"\xe2\x84\xa6")
 
         app.stop()
         thread.join()

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -24,7 +24,7 @@ from .utils import *  # noqa: F401,F403
 from .webapi import *  # noqa: F401,F403
 from .wsgi import *  # noqa: F401,F403
 
-__version__ = "0.70"
+__version__ = "0.75"
 __author__ = [
     "Aaron Swartz <me@aaronsw.com>",
     "Anand Chitipothu <anandology@gmail.com>",

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -1,5 +1,4 @@
-"""Utilities for make the code run both on Python2 and Python3.
-"""
+"""Utilities for make the code run both on Python2 and Python3."""
 
 # Dictionary iteration
 iterkeys = lambda d: iter(d.keys())


### PR DESCRIPTION
1. Separate the linting from the testing.
2. `pre-commit autoupdate && pre-commit run --all`
3. Format Python code with ruff format instead of black.

@scottbarnes At https://github.com/webpy/webpy/releases there is a DRAFT release for v0.75.
Please review this PR and that DRAFT release so that we can create a new release to PyPI using #797 (merged)
* #797 