### PR TITLE
Fix: disable accessing special variables from template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,5 @@ lint.pylint.max-branches = 17 # default is 12
 lint.pylint.max-returns = 8 # default is 6
 
 [tool.codespell]
-ignore-words-list = "asend,gae,notin"
+ignore-words-list = "asend,gae,notin,requireds"
 skip = [ "./.*" ]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -65,6 +65,34 @@ class TemplateTest(unittest.TestCase):
         f = t(template, globals={"item": TestItem()})
         assert repr(f()) == "'<a href=\"/del/12345\">Delete</a>\\n'"
 
+    def testImportMustFail(self):
+        tpl = "${__import__('os').getpwd()}"
+        self.assertRaises(SecurityError, t, tpl)
+
+    def test_SecutityError_name(self):
+        tpl = "$__special_name"
+        self.assertRaises(SecurityError, Template, tpl)
+
+        tpl = "${__special_name}"
+        self.assertRaises(SecurityError, Template, tpl)
+
+        tpl = "$var foo = __special_name"
+        self.assertRaises(SecurityError, Template, tpl)
+
+    def test_SecutityError_attr(self):
+        tpl = "$foo._private"
+        self.assertRaises(SecurityError, Template, tpl)
+
+        tpl = "$foo()._private"
+        self.assertRaises(SecurityError, Template, tpl)
+
+    def test_SecutityError_not_allowed_nodes(self):
+        tpl = "$code: import os"
+        self.assertRaises(SecurityError, Template, tpl)
+
+        tpl = "$code: raise Exception('x')"
+        self.assertRaises(SecurityError, Template, tpl)
+
 
 class TestParser(unittest.TestCase):
     """

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -16,7 +16,7 @@ class WSGITest(unittest.TestCase):
 
         class uni:
             def GET(self):
-                return "\u0C05\u0C06"
+                return "\u0c05\u0c06"
 
         app = web.application(urls, locals())
 
@@ -27,7 +27,7 @@ class WSGITest(unittest.TestCase):
         b = web.browser.AppBrowser(app)
         r = b.open("/").read()
         s = r.decode("utf8")
-        self.assertEqual(s, "\u0C05\u0C06")
+        self.assertEqual(s, "\u0c05\u0c06")
 
         app.stop()
         thread.join()
@@ -68,7 +68,7 @@ class WSGITest(unittest.TestCase):
         b = web.browser.AppBrowser(app)
         r = b.open("/%E2%84%A6")
         s = unquote(r.read())
-        self.assertEqual(s, b"\xE2\x84\xA6")
+        self.assertEqual(s, b"\xe2\x84\xa6")
 
         app.stop()
         thread.join()

--- a/web/py3helpers.py
+++ b/web/py3helpers.py
@@ -1,5 +1,4 @@
-"""Utilities for make the code run both on Python2 and Python3.
-"""
+"""Utilities for make the code run both on Python2 and Python3."""
 
 # Dictionary iteration
 iterkeys = lambda d: iter(d.keys())


### PR DESCRIPTION
Before this fix, it was possible to import modules from templates, which opens the possibility of RCE. This applies only when templates from untrusted users is allowed in the application. While this is not a common scenario, given the design goals of web.py templating system to be sandboxable, this is a serious flaw.

This commit fixes that issue by rejecting access to special variables with names starting with `__` at the compile time.

Fixes #801.