### PR TITLE
Remove required Python version limit 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = { file = "README.md", content-type = "text/plain" }
 license = { text = "Public domain" }
 maintainers = [ { name = "Anand Chitipothu", email = "anandology@gmail.com" } ]
 authors = [ { name = "Aaron Swartz", email = "me@aaronsw.com" } ]
-requires-python = ">=3.8,<=3.13"
+requires-python = ">=3.8"
 classifiers = [
   "License :: Public Domain",
   "Programming Language :: Python",


### PR DESCRIPTION
When I install web.py, but My Mac 's Python version is 1.13.3 , Install failed , and error below 


```bash 
$ python3 -m pip install --break-system-packages  git+https://github.com/webpy/webpy.git@master
Collecting git+https://github.com/webpy/webpy.git@master
  Cloning https://github.com/webpy/webpy.git (to revision master) to /private/var/folders/2t/1byvfl3s413gjq5btbg589gm0000gn/T/pip-req-build-zr2hvjez
  Running command git clone --filter=blob:none --quiet https://github.com/webpy/webpy.git /private/var/folders/2t/1byvfl3s413gjq5btbg589gm0000gn/T/pip-req-build-zr2hvjez
  Resolved https://github.com/webpy/webpy.git to commit 9aeaf55261086bee5b80cfd26928add0ec2af647
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: cheroot>=6.0.0 in /usr/local/lib/python3.13/site-packages (from web-py==0.70) (10.0.1)
Requirement already satisfied: more_itertools>=2.6 in /usr/local/lib/python3.13/site-packages (from web-py==0.70) (10.6.0)
Requirement already satisfied: multipart>=0.2.4 in /usr/local/lib/python3.13/site-packages (from web-py==0.70) (1.2.1)
INFO: pip is looking at multiple versions of web-py to determine which version is compatible with other requirements. This could take a while.
ERROR: Package 'web-py' requires a different Python: 3.13.3 not in '<=3.13,>=3.8'
```


Then remove version limit , it Works 


```bash 
$ python3 -m pip install --break-system-packages  git+https://github.com/Hyvi/webpy.git@master
Collecting git+https://github.com/Hyvi/webpy.git@master
  Cloning https://github.com/Hyvi/webpy.git (to revision master) to /private/var/folders/2t/1byvfl3s413gjq5btbg589gm0000gn/T/pip-req-build-l70qeuld
  Running command git clone --filter=blob:none --quiet https://github.com/Hyvi/webpy.git /private/var/folders/2t/1byvfl3s413gjq5btbg589gm0000gn/T/pip-req-build-l70qeuld
  Resolved https://github.com/Hyvi/webpy.git to commit a9c100e3e765cc090faf010aaaaf1f6614a4d6bc
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: cheroot>=6.0.0 in /usr/local/lib/python3.13/site-packages (from web-py==0.70) (10.0.1)
Requirement already satisfied: more_itertools>=2.6 in /usr/local/lib/python3.13/site-packages (from web-py==0.70) (10.6.0)
Requirement already satisfied: multipart>=0.2.4 in /usr/local/lib/python3.13/site-packages (from web-py==0.70) (1.2.1)
Requirement already satisfied: jaraco.functools in /usr/local/lib/python3.13/site-packages (from cheroot>=6.0.0->web-py==0.70) (4.1.0)
Building wheels for collected packages: web-py
  Building wheel for web-py (pyproject.toml) ... done
  Created wheel for web-py: filename=web_py-0.70-py3-none-any.whl size=78638 sha256=a6981895ac5993911424eb9bae32a9c9c4ce417c1d1a73a0c9f89ba9e9419933
  Stored in directory: /private/var/folders/2t/1byvfl3s413gjq5btbg589gm0000gn/T/pip-ephem-wheel-cache-jkip2rdk/wheels/b1/fe/1f/c671956d64fc471d6f7fbead2e66cccc4a5a616d22401ce6a2
Successfully built web-py
Installing collected packages: web-py
```

