### PR TITLE
pyproject.toml: rework license information

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
       # args: [--fix, --exit-non-zero-on-fix]
 
 -   repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.23
+    rev: v0.25
     hooks:
     - id: validate-pyproject
 
 -   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.5.0
+    rev: v2.23.0
     hooks:
     - id: pyproject-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ requires = [
 name = "web-py"
 description = "web.py: makes web apps"
 readme = { file = "README.md", content-type = "text/plain" }
-license = { text = "Public domain" }
+license = "LicenseRef-Public-Domain-1.0"
+license-files = ["LICENSE.txt"]
 maintainers = [ { name = "Anand Chitipothu", email = "anandology@gmail.com" } ]
 authors = [ { name = "Aaron Swartz", email = "me@aaronsw.com" } ]
 requires-python = ">=3.10,<3.15"
 classifiers = [
-  "License :: Public Domain",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "web-py"
 description = "web.py: makes web apps"
 readme = { file = "README.md", content-type = "text/plain" }
 license = "LicenseRef-Public-Domain-1.0"
-license-files = ["LICENSE.txt"]
+license-files = [ "LICENSE.txt" ]
 maintainers = [ { name = "Anand Chitipothu", email = "anandology@gmail.com" } ]
 authors = [ { name = "Aaron Swartz", email = "me@aaronsw.com" } ]
 requires-python = ">=3.10,<3.15"
@@ -31,12 +31,10 @@ urls.Source = "https://github.com/webpy/webpy"
 
 [tool.setuptools]
 packages = [ "web", "web.contrib" ]
-platforms = [ "any" ]
 include-package-data = false
-
-[tool.setuptools.dynamic]
-version = { attr = "web.__version__" }
-dependencies = { file = [ "requirements.txt" ] }
+dynamic.dependencies = { file = [ "requirements.txt" ] }
+dynamic.version = { attr = "web.__version__" }
+platforms = [ "any" ]
 
 [tool.black]
 exclude = '''
@@ -60,7 +58,6 @@ exclude = '''
 
 [tool.ruff]
 target-version = "py310"
-
 line-length = 320
 lint.select = [
   "C9",
@@ -80,12 +77,13 @@ lint.ignore = [
   "PLC0415",
   "PLR5501",
   "UP031",
+  "UP038",
 ]
 lint.mccabe.max-complexity = 20
 lint.pylint.allow-magic-value-types = [ "int", "str" ]
-lint.pylint.max-args = 9 # default is 5
-lint.pylint.max-branches = 17 # default is 12
-lint.pylint.max-returns = 8 # default is 6
+lint.pylint.max-args = 9  # default is 5
+lint.pylint.max-branches = 17  # default is 12
+lint.pylint.max-returns = 8  # default is 6
 
 [tool.codespell]
 ignore-words-list = "asend,gae,notin,requireds"


### PR DESCRIPTION
Don't use license info in the classifiers section define both license and license file via the new options.

This resolves the following issues:

```
*********************************************************************** 
Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

This deprecation is overdue, please update your project and remove deprecated calls to avoid build errors in the future.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. 
***********************************************************************
```

```
*********************************************************************** 
Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: Public Domain

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. 
***********************************************************************
```