### PR TITLE
fix broken doctest examples in net.py

### DIFF
--- a/web/net.py
+++ b/web/net.py
@@ -221,7 +221,7 @@ def htmlquote(text):
     Encodes `text` for raw use in HTML.
 
         >>> htmlquote(u"<'&\">")
-        u'&lt;&#39;&amp;&quot;&gt;'
+        '&lt;&#39;&amp;&quot;&gt;'
     """
     text = text.replace("&", "&amp;")  # Must be done first!
     text = text.replace("<", "&lt;")
@@ -236,7 +236,7 @@ def htmlunquote(text):
     Decodes `text` that's HTML quoted.
 
         >>> htmlunquote(u'&lt;&#39;&amp;&quot;&gt;')
-        u'<\'&">'
+        '<\'&">'
     """
     text = text.replace("&quot;", '"')
     text = text.replace("&#39;", "'")
@@ -251,9 +251,9 @@ def websafe(val):
     Converts `val` so that it is safe for use in Unicode HTML.
 
         >>> websafe("<'&\">")
-        u'&lt;&#39;&amp;&quot;&gt;'
+        '&lt;&#39;&amp;&quot;&gt;'
         >>> websafe(None)
-        u''
+        ''
         >>> websafe(u'\u203d') == u'\u203d'
         True
     """


### PR DESCRIPTION
I've tried to run net.py and received these failures:

```
3 items had failures:
   1 of   1 in __main__.htmlquote
   1 of   1 in __main__.htmlunquote
   2 of   3 in __main__.websafe
***Test Failed*** 4 failures.
``` 

I've figured out that these failures were caused by the u string prefix in the expected outputs in htmlquote, htmlunquote and websafe, as shown in this error example:

```
Failed example:
    websafe(None)
Expected:
    u''
Got:
    ''
```

So i removed them because in python3 they are no longer necessary. Since i touched only docstrings, no logic was changed and when I reran net.py I received no output, so the doctests passed successfully.